### PR TITLE
setting nurbs weights the old way

### DIFF
--- a/python/vtool/data.py
+++ b/python/vtool/data.py
@@ -1356,8 +1356,6 @@ class SkinWeightData(MayaCustomData):
         
         influences = list(influences)
         
-        
-        
         transfer_mesh = None
         
         import_obj = True
@@ -1423,6 +1421,11 @@ class SkinWeightData(MayaCustomData):
         self._progress_ui.status('Importing skin weights on: %s    - start import skin weights' % nicename)
         
         new_way = True
+        
+        nurbs_types = ['nurbsCurve', 'nurbsSurface']
+        for nurbs_type in nurbs_types:
+            if maya_lib.core.has_shape_of_type(mesh, nurbs_type):
+                new_way = False
         
         if new_way:
             

--- a/python/vtool/version.txt
+++ b/python/vtool/version.txt
@@ -1,1 +1,1 @@
-version: 0.5.5
+version: 0.5.5.01


### PR DESCRIPTION
Importing onto skin cluster using setAttr instead of the maya API.  Nurbs generally don't have as many points to loop through as meshes, so they don't need the api speed boost.
When I have more time I will look again at getting it to work with the API for nurbs 