### PR TITLE
fixed a typo in a check for Python 3

### DIFF
--- a/python/vtool/util_file.py
+++ b/python/vtool/util_file.py
@@ -3121,7 +3121,7 @@ def get_ast_function_args(function_node):
                 if hasattr(default_value, 'elts'):
                     if not default_value.elts:
                         value = '[]'
-            if util.python_version > 2:
+            if util.python_version > 3:
                 if isinstance(default_value,ast.NameConstant):
                     value = default_value.value
                 


### PR DESCRIPTION
util_file.get_ast_function_args() had a typo in a check in what should have been "python_version > 3", causing a failure when run in Python 2.7.