### PR TITLE
Skin nurbs from mesh fix

### DIFF
--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -6499,11 +6499,7 @@ def skin_group(joints, group, dropoff_rate = 4.0):
             pass
 
 def skin_nurbs_from_mesh(source_mesh, target_nurbs):
-    
-    existing_skin = find_deformer_by_type(target_nurbs, 'skinCluster')
-    if existing_skin:
-        cmds.delete(existing_skin)
-    
+        
     mesh = source_mesh
     nurbs = target_nurbs
     
@@ -6518,6 +6514,10 @@ def skin_nurbs_from_mesh(source_mesh, target_nurbs):
     
     influences = get_influences_on_skin(mesh_skin,short_name = False)
     mesh_skin_weights = get_skin_weights(mesh_skin)
+
+    existing_skin = find_deformer_by_type(target_nurbs, 'skinCluster')
+    if existing_skin:
+        cmds.delete(existing_skin)
 
     skin = SkinCluster(nurbs)
     skin_name = skin.get_skin()

--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -6514,7 +6514,7 @@ def skin_nurbs_from_mesh(source_mesh, target_nurbs):
     influences = get_influences_on_skin(mesh_skin,short_name = False)
     mesh_skin_weights = get_skin_weights(mesh_skin)
 
-    existing_skin = find_deformer_by_type(target_nurbs, 'skinCluster')
+    existing_skin = find_deformer_by_type(nurbs, 'skinCluster')
     if existing_skin:
         cmds.delete(existing_skin)
 

--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -6499,6 +6499,10 @@ def skin_group(joints, group, dropoff_rate = 4.0):
             pass
 
 def skin_nurbs_from_mesh(source_mesh, target_nurbs):
+    
+    existing_skin = find_deformer_by_type(target_nurbs, 'skinCluster')
+    cmds.delete(existing_skin)
+    
     mesh = source_mesh
     nurbs = target_nurbs
     

--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -6499,7 +6499,6 @@ def skin_group(joints, group, dropoff_rate = 4.0):
             pass
 
 def skin_nurbs_from_mesh(source_mesh, target_nurbs):
-        
     mesh = source_mesh
     nurbs = target_nurbs
     

--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -6501,7 +6501,8 @@ def skin_group(joints, group, dropoff_rate = 4.0):
 def skin_nurbs_from_mesh(source_mesh, target_nurbs):
     
     existing_skin = find_deformer_by_type(target_nurbs, 'skinCluster')
-    cmds.delete(existing_skin)
+    if existing_skin:
+        cmds.delete(existing_skin)
     
     mesh = source_mesh
     nurbs = target_nurbs

--- a/python/vtool/version.txt
+++ b/python/vtool/version.txt
@@ -1,1 +1,1 @@
-version: 0.5.5.4
+version: 0.5.5.5


### PR DESCRIPTION
This removes the existing skin cluster on the nurbs surface if it exists before building the new one. 