### PR TITLE
Bug Fix: Pass selection to skin cluster export

### DIFF
--- a/python/vtool/data.py
+++ b/python/vtool/data.py
@@ -1606,7 +1606,6 @@ class SkinWeightData(MayaCustomData):
         
         progress = maya_lib.core.ProgressBar('Exporting skin weights on:', len(selection))
         
-        
         for thing in selection:
             
             progress.status('Exporting skin weights on %s ' % (maya_lib.core.get_basename(thing)))

--- a/python/vtool/maya_lib/core.py
+++ b/python/vtool/maya_lib/core.py
@@ -932,12 +932,12 @@ def get_node_types(nodes, return_shape_type = True):
     
 def get_transforms_with_shape_of_type(shape_type):
     
-    shapes = cmds.ls(type = shape_type)
+    shapes = cmds.ls(type = shape_type, l = True)
     
     parents = {}
     
     for shape in shapes:
-        parent = cmds.listRelatives(shape, p = True)
+        parent = cmds.listRelatives(shape, p = True, f = True)
         if parent:
             parents[parent[0]] = None
             

--- a/python/vtool/process_manager/process.py
+++ b/python/vtool/process_manager/process.py
@@ -1380,11 +1380,18 @@ class Process(object):
                 
         if not comment:
             comment = 'Exported through process class with no comment.'
-            
+        
         if hasattr(instance, 'export_data'):
-            
-            arg_spec = inspect.getargspec(instance.export_data)
-            if 'selection' in arg_spec.args and list_to_export:
+            selection_pass = False
+            if util.python_version > 3:
+                signature = inspect.signature(instance.export_data)
+                if 'selection' in signature.parameters and list_to_export:
+                    selection_pass = True
+            if util.python_version < 3:
+                arg_spec = inspect.getargspec(instance.export_data)
+                if 'selection' in arg_spec.args and list_to_export:
+                    selection_pass = True
+            if selection_pass:
                 exported = instance.export_data(comment, selection = list_to_export)
             else:
                 exported = instance.export_data(comment)

--- a/python/vtool/qt_ui.py
+++ b/python/vtool/qt_ui.py
@@ -5811,11 +5811,13 @@ class PythonCompleter(qt.QCompleter):
                         sub_variables = self.current_sub_variables
                     
                 if not sub_functions:
-                    sub_functions, sub_variables = util_file.get_ast_class_sub_functions(path, sub_part)
-                    if sub_functions:
-                        self.current_sub_functions = sub_functions
-                    if sub_variables:
-                        self.current_sub_variables = sub_variables
+                    result = util_file.get_ast_class_sub_functions(path, sub_part)
+                    if result:
+                        sub_functions, sub_variables = result
+                        if sub_functions:
+                            self.current_sub_functions = sub_functions
+                        if sub_variables:
+                            self.current_sub_variables = sub_variables
                 
                 self.last_path_and_part = [path, sub_part]
                 

--- a/python/vtool/util_file.py
+++ b/python/vtool/util_file.py
@@ -3102,7 +3102,6 @@ def get_ast_function_args(function_node):
             default_value = defaults[inc]
         
         if default_value:
-            
             value = None
             
             if isinstance(default_value, ast.Str):
@@ -3118,6 +3117,8 @@ def get_ast_function_args(function_node):
                         value = '[]'
             if util.python_version > 3:
                 if isinstance(default_value,ast.Constant):
+                    value = default_value.value
+                if isinstance(default_value, ast.NameConstant):
                     value = default_value.value
                 
             if value == None:


### PR DESCRIPTION
process.export_data on weight skin cluster data now properly passes the selection list
Python 3 introduced a bug where the list was not getting passed properly. 
Also this fixes a bug where meshes in a hierarchy that no longer exists will not error and stop the import of skin weights. 