### PR TITLE
Fix: IkAppendageRig.set_stretchy_type(1) joint chain not parented under setup correctly.

### DIFF
--- a/python/vtool/maya_lib/rigs.py
+++ b/python/vtool/maya_lib/rigs.py
@@ -4686,12 +4686,8 @@ class IkAppendageRig(BufferRig):
                 
         if not self.create_buffer_joints:
             pass
-            #util.AttachJoints(self.ik_chain, self.buffer_joints).create()
         
         if self.create_buffer_joints:
-                
-            
-            #self._attach_ik_joints(self.ik_chain, self.buffer_joints)
             
             ik_group = self._create_group()
             cmds.parent(self.ik_chain[0], ik_group)

--- a/python/vtool/maya_lib/rigs_util.py
+++ b/python/vtool/maya_lib/rigs_util.py
@@ -1445,8 +1445,12 @@ class StretchyElbowLock(object):
             found.append(new)
             
         cmds.hide(found[0])
-            
+        
         self.dup_joints = found
+        
+        parent = cmds.listRelatives(found[0], p = True)
+        if not parent:
+            cmds.parent(parent, self._parent)
     
     def _create_distance(self, transform1, transform2):
         
@@ -1468,8 +1472,6 @@ class StretchyElbowLock(object):
             cmds.connectAttr('%s.output' % add_double_linear, input_attribute)
         
         return add_double_linear
-    
-    
     
     def _multiply_divide(self, attribute1, attribute2, input_attribute = None):
         

--- a/python/vtool/maya_lib/rigs_util.py
+++ b/python/vtool/maya_lib/rigs_util.py
@@ -1450,7 +1450,7 @@ class StretchyElbowLock(object):
         
         parent = cmds.listRelatives(found[0], p = True)
         if not parent:
-            cmds.parent(parent, self._parent)
+            cmds.parent(found[0], self._parent)
     
     def _create_distance(self, transform1, transform2):
         

--- a/python/vtool/run_script_manager.py
+++ b/python/vtool/run_script_manager.py
@@ -6,12 +6,7 @@ import sys
 
 from vtool import qt_ui
 
-from vtool import util
-from vtool import util_file
-
 import script_manager.script_view as script_view
-
-
 
 def main(directory = None):
     


### PR DESCRIPTION
This code would create an ik setup where some setup joints were parented outside of the setup_group.

```import sys
sys.path.append('D:/dev/git/vtool/python')

from vtool.maya_lib import rigs

import maya.cmds as cmds

joints = cmds.ls(type = 'joint')

rig = rigs.IkAppendageRig('test')
rig.set_joints(joints[:3])
rig.set_pole_offset(0.5)
rig.set_stretch_type(1)
rig.create()```