### PR TITLE
Fix: script_manager edit state when clicking away

### DIFF
--- a/python/vtool/qt_ui.py
+++ b/python/vtool/qt_ui.py
@@ -652,6 +652,9 @@ class TreeWidget(qt.QTreeWidget):
         if not hasattr(self.edit_state, 'text'):
             return
         
+        if not item and self.edit_state:
+            item = self.edit_state
+        
         self.edit_state = None
                
         


### PR DESCRIPTION
When clicking away from an object the edit state would remain open.