### PR TITLE
Fix: Fk use_hierarhcy now deals better with side in the joint name

### DIFF
--- a/python/vtool/maya_lib/rigs.py
+++ b/python/vtool/maya_lib/rigs.py
@@ -1957,21 +1957,36 @@ class FkRig(BufferRig):
         
     def _create_control(self, description = '', sub = False, curve_type = ''):
         
+        orig_side = self.side
+        
         if self._use_hier_name:
             transform = self.current_transform
             transform = core.get_basename(transform, remove_attribute = True)
             transform = transform.replace(self.joint_name_token, '')
             transform = vtool.util.replace_last_number(transform, '')
             
+            transform, side = vtool.util.remove_side(transform)
+            if side:
+                side_code = vtool.util.get_side_code(side)
+                
+                self.side = side_code
+            
             if transform.endswith('_'):
                 transform = transform[:-1]
+            if transform.startswith('_'):
+                transform = transform[1:]
+            if transform.find('__'):
+                transform.replace('__','_')
             
             if description:
                 description = description + '_' + transform
             else:
                 description = transform
-                        
+            
         control = super(FkRig, self)._create_control(description, sub, curve_type)
+        
+        if self._use_hier_name:
+            self.side = orig_side
         
         if not sub:
             self.last_control = self.control

--- a/python/vtool/maya_lib/space.py
+++ b/python/vtool/maya_lib/space.py
@@ -4834,6 +4834,8 @@ def find_transform_left_side(transform,check_if_exists = True):
 
     return ''
 
+
+
 def mirror_toggle(transform, bool_value):
     
     if not cmds.objExists('%s.mirror' % transform):

--- a/python/vtool/maya_lib/space.py
+++ b/python/vtool/maya_lib/space.py
@@ -5626,4 +5626,33 @@ def orig_matrix_match(transform, destination_transform):
     except:
         pass
 
+def add_twist_reader(transform, read_axis = 'X'):
+    
+    read_axis = read_axis.upper()
+    
+    local_matrix = cmds.createNode('multMatrix', n = 'twistLocalMatrix_%s' % transform)
+    
+    cmds.connectAttr('%s.worldMatrix[0]' % transform, '%s.matrixIn[0]' % local_matrix)
+    cmds.connectAttr('%s.parentInverseMatrix[0]' % transform, '%s.matrixIn[1]' % local_matrix)
+    
+    local_matrix_offset = cmds.getAttr('%s.inverseMatrix' % transform)
+    cmds.setAttr('%s.matrixIn[2]' % local_matrix, *local_matrix_offset, type = 'matrix')
+    
+    decompose = cmds.createNode('decomposeMatrix', n = 'twistDecompose_%s' % transform)
+    
+    cmds.connectAttr('%s.matrixSum' % local_matrix, '%s.inputMatrix' % decompose)
+    
+    normalize = cmds.createNode('quatNormalize', n = 'twistNormalize_%s' % transform)
+    
+    cmds.connectAttr('%s.outputQuat%s' % (decompose, read_axis), '%s.inputQuat%s' % (normalize,read_axis))
+    cmds.connectAttr('%s.outputQuatW' % decompose, '%s.inputQuatW' % normalize)
+    
+    euler = cmds.createNode('quatToEuler', n = 'twistEuler_%s' % transform)
+    
+    cmds.addAttr(transform, ln = 'twist', k = True)
+    
+    cmds.connectAttr('%s.outputQuat' % normalize, '%s.inputQuat' % euler)
+    
+    cmds.connectAttr('%s.outputRotate%s' % (euler, read_axis), '%s.twist' % transform)
+    
     

--- a/python/vtool/util.py
+++ b/python/vtool/util.py
@@ -2034,6 +2034,56 @@ def camel_to_underscore(name):
     s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
+def remove_side(name):
+    
+    ending_cases = ['_L','_R','_l','_r','_lf','_rt','_C','_c']
+    starting_cases = ['L_', 'R_', 'l_', 'r_','lf_','rt_','C_','c_']
+    anyplace_cases = ['Left', 'Right','left','right','_L_','_R_','_l_','_r_','_lf_','_rt_','Center','center','_C_','_c_']
+    
+    for end_case in ending_cases:
+        if name.endswith(end_case):
+            return name[:-2], name[-1]
+    
+    for start_case in starting_cases:
+        if name.startswith(start_case):
+            return name[2:], name[0]
+    
+    for anyplace_case in anyplace_cases:
+        find_index = name.find(anyplace_case)
+        if find_index > -1:
+            
+            replace_string = ''
+            
+            if anyplace_case.startswith('_') and anyplace_case.endswith('_'):
+                replace_string = '_'
+            
+            new_name = name[:find_index] + replace_string + name[find_index+len(anyplace_case):]
+            side = anyplace_case.strip('_')
+            
+            if not replace_string:
+                if new_name[find_index] == '_' and new_name[(find_index - 1)] == '_':
+                    new_name = new_name[:(find_index-1)] + '_' + new_name[(find_index+1):]
+            
+            return new_name, side
+        
+    return name,None
+
+def get_side_code(side_name):
+    """
+    given a side name like: Left,left,L,lf,l this will return L
+    given a side name like: Right,right,R,rt,r this will return R
+    given a side name like: Center,center,C,ct,c this will return C
+    """
+    
+    if side_name.find('C') > -1 or side_name.find('c') > -1:
+        return 'C'
+    
+    if side_name.find('L') > -1 or side_name.find('l') > -1:
+        return 'L'
+    
+    if side_name.find('R') > -1 or side_name.find('r') > -1:
+        return 'R'
+    
 #--- output
 
 def get_tabs():


### PR DESCRIPTION
In a future release it will try to find the side of the joint and use it properly in the control name. 
Currently its putting the side in the wrong place, for example, if the joint is named   'JNT_goo_L '  then the control is getting named 'CNT_TEST_GOO_L_1' instead of 'CNT_TEST_GOO_1_L' 

this also will introduce 2 new functions in the util module
util.remove_side(name) returning the string with the side removed, and the side string that it found.   Side strings include 'Left','Right','left','right','L','R','l','r','lf','rt', etc
so if you give it
joint_goooLeft_1 it will return [joint_gooo_1,Left]
the other function is
util.get_side_code(side_name) return the side, ie, C or L or R
so if you give it one of Left, left, l, lf, etc... it will return L
These functions could be helpful when building custom setups that need to deal with side