### PR TITLE
Fix: ground rig with new pre check

### DIFF
--- a/python/vtool/maya_lib/rigs.py
+++ b/python/vtool/maya_lib/rigs.py
@@ -1856,6 +1856,10 @@ class GroundRig(JointRig):
         self.sub_control_size = .9
         self.scalable = False
 
+    def _pre_create(self):
+        super(JointRig, self)._pre_create()
+        vtool.util.show('Using joints:%s' % self.joints)
+        
     def set_joints(self, joints = None):
         super(GroundRig, self).set_joints(joints)
         


### PR DESCRIPTION
this fixes an issue where the ground rig wouldn't build because of a new pre create function that checks if the rig has joints passed in.  Ground rig doesn't require joints to be passed in.