### PR TITLE
Fix: batch mode, making it more stable

### DIFF
--- a/python/vtool/process_manager/batch.py
+++ b/python/vtool/process_manager/batch.py
@@ -2,6 +2,14 @@
 
 from __future__ import print_function
 
+from pathlib import Path
+
+vetala_path = Path(__file__).parents[2]
+import sys
+sys.path.append(str(vetala_path) + '/')
+
+print('Using Vetala Path: ', vetala_path)
+
 import vtool.util
 import vtool.util_file
 
@@ -11,9 +19,7 @@ import time
 import traceback
 
 def main():
-    
-    
-    
+        
     print( '\n\n\n\n\n------- VETALA BATCH --------------------------------------------------------------------------------------------\n\n')
     
     process_path = os.environ['VETALA_CURRENT_PROCESS']
@@ -80,12 +86,15 @@ def main():
     else:
         vtool.util.show('Could not get current process.  Batch finished, nothing processed.')
 
-    vtool.util.show('\n\nAll done, please close console.')
+    vtool.util.show('\n\nAll done!')
     
-    while True:
-        time.sleep(1)
-    
+    python_version = vtool.util.get_python_version()
+    if python_version == 3:
+        input('\n\nPress Any Key to Exit')
+    if python_version == 2:
+        raw_input('\n\nPress Any Key to Exit')
+
     print( '\n\n------- END OF VETALA BATCH ----------------------------------------------------------\n\n\n\n\n')
-    
+
 if __name__ == '__main__':
     main()

--- a/python/vtool/util.py
+++ b/python/vtool/util.py
@@ -411,6 +411,9 @@ if is_in_maya():
     else:
         pymel = None
 
+def get_python_version():
+    return sys.version_info[0]
+
 def has_shotgun_api():
     """
     Check if the shotgun api is available.

--- a/python/vtool/util_file.py
+++ b/python/vtool/util_file.py
@@ -3376,9 +3376,18 @@ def get_mayapy():
         return
     
     mayapy_file = 'mayapy.exe'
+    python_version = util.get_python_version()
+
+    if util.get_maya_version() > 2021:
+        if python_version < 3:
+            mayapy_file = 'mayapy2.exe'
     
     if util.is_linux():
         mayapy_file = 'mayapy'
+
+        if util.get_maya_version() > 2021:
+            if python_version < 3:
+                mayapy_file = 'mayapy2'
     
     mayapy_path = '%s/bin/%s' % (dirpath,mayapy_file)    
     


### PR DESCRIPTION
Batch mode was dependent on Vetala being in the python path.  It now automatically finds Vetala based on the location of the batch file, and adds it to the sys.path.

Also some logic for finding the right mayapy executable when in Maya 2022 and above. 

When process ends any key can now be pressed to close the terminal.  This avoids having a maya crash log started every time you close the terminal (might just be a windows 11 thing)