### PR TITLE
Fix: error when removing tag in shape combo ui

### DIFF
--- a/python/vtool/maya_lib/blendshape.py
+++ b/python/vtool/maya_lib/blendshape.py
@@ -2165,7 +2165,8 @@ class ShapeComboManager(object):
         
         shapes = self.get_tag(tag_name)
         
-        data_dict.pop(tag_name)
+        if tag_name in data_dict:
+            data_dict.pop(tag_name)
         
         store.set_data(data_dict)
         

--- a/python/vtool/maya_lib/ui_lib/ui_shape_combo.py
+++ b/python/vtool/maya_lib/ui_lib/ui_shape_combo.py
@@ -1616,8 +1616,10 @@ class TagManager(qt_ui.BasicDialog):
         
         if not items:
             items = self.tag_list.selectedItems()
-        
+
         for item in items:
+            if not item:
+                continue
             index = self.tag_list.indexFromItem(item)
             self.tag_list.takeItem(index.row())
         


### PR DESCRIPTION
fixes this error:
```
# Traceback (most recent call last):
#   File "E:/dev/git/vtool/python\vtool\maya_lib\ui_lib\ui_shape_combo.py", line 1574, in _right_click_remove_tag
#     self.remove_tag(self._right_click_tag)
#   File "E:/dev/git/vtool/python\vtool\maya_lib\ui_lib\ui_shape_combo.py", line 1625, in remove_tag
#     self.manager.remove_tag(tag_name)
#   File "E:/dev/git/vtool/python\vtool\maya_lib\blendshape.py", line 2142, in remove_tag
#     data_dict.pop(tag_name)
# KeyError: 'test'
```