### PR TITLE
Fix: geo.transforms_to_polygon uv history fix

### DIFF
--- a/python/vtool/maya_lib/geo.py
+++ b/python/vtool/maya_lib/geo.py
@@ -2886,7 +2886,7 @@ def transform_to_polygon_plane(transform, size = 1, axis = 'Y'):
     if axis == 'Z':
         axis_vector = [0,0,1]
     
-    plane = cmds.polyPlane( w = size, h = size, sx = 1, sy = 1, ax = axis_vector, ch = 0)
+    plane = cmds.polyPlane( w = size, h = size, sx = 1, sy = 1, ax = axis_vector, ch = 0, cuv = 1)
     
     plane = cmds.rename(plane, core.inc_name('%s_plane' % transform))
     
@@ -2915,7 +2915,8 @@ def transforms_to_polygon(transforms, name, size = 1, merge = True, axis = 'Y'):
             
         if len(transforms) == 1:
             new_mesh = cmds.rename(meshes[0], name)
-        cmds.polyLayoutUV(new_mesh, lm = 1)
+        cmds.polyLayoutUV(new_mesh, lm = 1, ch = 0)
+        
         
     if new_mesh:
         return new_mesh


### PR DESCRIPTION
geo.transforms_to_polygon was leaving uv history on the mesh.  This was affecting uv pin constraints adversely 