### PR TITLE
Fix:  Data Sidebar Setting and Code Text Size 

### DIFF
--- a/python/vtool/process_manager/ui_data.py
+++ b/python/vtool/process_manager/ui_data.py
@@ -47,27 +47,23 @@ class DataProcessWidget(qt_ui.DirectoryWidget):
         self.data_tree_widget.active_folder_changed.connect(self._update_file_widget)
         self.data_tree_widget.data_added.connect(self._add_data)
         
-        if self.sidebar:
-            self.datatype_widget = DataTypeWidget()
-            self.datatype_widget.data_added.connect(self._add_data)
-        
         splitter.setSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding)   
         self.main_layout.addWidget(splitter, stretch = 1)
                 
         splitter.addWidget(self.data_tree_widget)
+        self.splitter = splitter
+        
         if self.sidebar:
-            splitter.addWidget(self.datatype_widget)
+            self._add_sidebar()
         
         splitter.setSizes([1,1])
-        self.splitter = splitter
         
         self.label = qt.QLabel('-')
         font = self.label.font()
         font.setBold(True)
         font.setPixelSize(12)
-        self.label.setMinimumHeight(30)
+        self.label.setMinimumHeight(util.scale_dpi(30))
         self.label.setFont(font)
-        self.label.show()
         
         self.data_widget = DataWidget()
         self.data_widget.hide()
@@ -81,6 +77,16 @@ class DataProcessWidget(qt_ui.DirectoryWidget):
         
         self.main_layout.addWidget(self.label, alignment = qt.QtCore.Qt.AlignCenter)
         self.main_layout.addWidget(self.data_widget)
+        
+    def _add_sidebar(self):
+        self.datatype_widget = DataTypeWidget()
+        self.datatype_widget.data_added.connect(self._add_data)
+        self.splitter.addWidget(self.datatype_widget)
+        
+    def _remove_sidebar(self):
+        
+        if self.datatype_widget:
+            self.datatype_widget.hide()
         
     def _data_updated(self):
         item = self.data_tree_widget.currentItem()
@@ -278,7 +284,12 @@ class DataProcessWidget(qt_ui.DirectoryWidget):
         
         self._set_title(basename)
         
-                
+    def set_sidebar_visible(self, bool_value):
+        if bool_value:
+            self._add_sidebar()
+        else:
+            self._remove_sidebar()
+        
     def set_directory(self, directory):
         super(DataProcessWidget, self).set_directory(directory)
 

--- a/python/vtool/process_manager/ui_process_manager.py
+++ b/python/vtool/process_manager/ui_process_manager.py
@@ -145,8 +145,7 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
         self._build_header()
         
         self._build_view()
-        self._build_view_header()
-                        
+        
         self._build_process_tabs()
         self._build_misc_tabs()
         
@@ -155,18 +154,21 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
         
         self._build_footer()
         
+        self.main_layout.addSpacing(util.scale_dpi(4))
         self.main_layout.addLayout(self.header_layout)
+        self.main_layout.addSpacing(util.scale_dpi(4))
         self.main_layout.addWidget(self.process_splitter)
-              
-        self.main_side_widget.main_layout.addSpacing(6)
+        
         self.main_side_widget.main_layout.addLayout(self.splitter_button_layout)
-        self.main_side_widget.main_layout.addSpacing(6)
+        self.main_side_widget.main_layout.addSpacing(util.scale_dpi(4))
         self.main_side_widget.main_layout.addWidget(self.process_tabs)
         
         btm_layout = qt.QVBoxLayout()
         btm_layout.addWidget(self.bottom_widget)
         
+        self.main_layout.addSpacing(4)
         self.main_layout.addLayout(btm_layout)
+        self.main_layout.addSpacing(4)
         
         self._build_settings_widget()
         
@@ -186,9 +188,42 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
         self.active_title = qt.QLabel('-')
         self.active_title.setAlignment(qt.QtCore.Qt.AlignCenter)
         
-        self.header_layout.addWidget(self.progress_bar, alignment = qt.QtCore.Qt.AlignLeft)
+        
+        if in_maya:
+            settings_icon = qt_ui.get_icon('gear.png')
+        else:
+            settings_icon = qt_ui.get_icon('gear2.png')
+        
+        settings = qt.QPushButton(settings_icon, 'Settings')
+        settings.setMaximumHeight(util.scale_dpi(20))
+        settings.setMaximumWidth(util.scale_dpi(100))
+        settings.clicked.connect(self._open_settings)
+        
+        self.browser_button = qt.QPushButton('Browse')
+        self.browser_button.setMaximumWidth(util.scale_dpi(70))
+        self.browser_button.setMaximumHeight(util.scale_dpi(20))
+        help_button = qt.QPushButton('?')
+        help_button.setMaximumWidth(util.scale_dpi(20))
+        help_button.setMaximumHeight(util.scale_dpi(20))
+        
+        self.browser_button.clicked.connect(self._browser)
+        help_button.clicked.connect(self._open_help)
+        
+        left_layout = qt.QHBoxLayout()
+        left_layout.addWidget(settings)
+        
+        right_layout = qt.QHBoxLayout()
+        right_layout.addWidget(self.info_title)
+        right_layout.addWidget(self.browser_button)
+        right_layout.addWidget(help_button)
+        right_layout.addWidget(self.progress_bar)
+        
+        
+        self.header_layout.addLayout(left_layout, alignment = qt.QtCore.Qt.AlignLeft)
+        
         self.header_layout.addWidget(self.active_title, alignment = qt.QtCore.Qt.AlignCenter)
-        self.header_layout.addWidget(self.info_title, alignment = qt.QtCore.Qt.AlignRight)
+        
+        self.header_layout.addLayout(right_layout, alignment = qt.QtCore.Qt.AlignRight)
     
     def _build_view(self):
         
@@ -208,37 +243,6 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
         self.view_widget.tree_widget.show_maintenance.connect(self._show_maintenaince)
         self.view_widget.tree_widget.process_deleted.connect(self._process_deleted)
         self.view_widget.path_filter_change.connect(self._update_path_filter)
-        
-    def _build_view_header(self):
-        
-        if in_maya:
-            settings_icon = qt_ui.get_icon('gear.png')
-        else:
-            settings_icon = qt_ui.get_icon('gear2.png')
-        
-        process_list_header = qt.QHBoxLayout()
-        
-        settings = qt.QPushButton(settings_icon, 'Settings')
-        settings.setMaximumHeight(util.scale_dpi(20))
-        settings.clicked.connect(self._open_settings)
-        
-        self.browser_button = qt.QPushButton('Browse')
-        self.browser_button.setMaximumWidth(util.scale_dpi(70))
-        self.browser_button.setMaximumHeight(util.scale_dpi(20))
-        help_button = qt.QPushButton('?')
-        help_button.setMaximumWidth(util.scale_dpi(20))
-        help_button.setMaximumHeight(util.scale_dpi(20))
-        
-        self.browser_button.clicked.connect(self._browser)
-        help_button.clicked.connect(self._open_help)
-        
-        process_list_header.addWidget(settings)
-        process_list_header.addStretch(1)
-        process_list_header.addWidget(self.browser_button)
-        process_list_header.addWidget(help_button)
-        
-        self.view_widget.main_layout.insertLayout(0, process_list_header)
-        self.view_widget.main_layout.insertSpacing(1, 10)
         
     def _build_splitter(self):
         self.process_splitter = qt.QSplitter()
@@ -355,9 +359,10 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
                                          "Somtimes holding ESC works better.\n"
                                          "Use the build widget below to save the process after it finishes.")
 
+        height = util.scale_dpi(25)
         self.process_button.setDisabled(True)
         self.process_button.setMinimumWidth(70)
-        self.process_button.setMinimumHeight(30)
+        self.process_button.setMinimumHeight(height)
         
         build_layout = qt.QHBoxLayout()
         build_label = qt.QLabel('BUILD')
@@ -366,13 +371,13 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
         save_button = qt_ui.BasicButton('Save')
         
         save_button.setMaximumWidth(util.scale_dpi(40))
-        save_button.setMinimumHeight(util.scale_dpi(30))
+        save_button.setMinimumHeight(height)
         
         save_button.clicked.connect(self._save_build)
         
         open_button = qt_ui.BasicButton('Open')
         open_button.setMaximumWidth(util.scale_dpi(45))
-        open_button.setMinimumHeight(util.scale_dpi(30))
+        open_button.setMinimumHeight(height)
         
         open_button.clicked.connect(self._open_build)
         
@@ -385,23 +390,23 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
         self.batch_button.setWhatsThis('Batch button \n\n'
                                         'This will do the same as the Process button, but it will run it in Maya Batch mode.')
         self.batch_button.setDisabled(True)
-        self.batch_button.setMinimumHeight(30)
+        self.batch_button.setMinimumHeight(height)
         self.batch_button.setMinimumWidth(70)
         
         self.deadline_button = qt.QPushButton('DEADLINE')
         self.deadline_button.setDisabled(True)
-        self.deadline_button.setMinimumHeight(30)
+        self.deadline_button.setMinimumHeight(height)
         self.deadline_button.setMinimumWidth(70)
         self.deadline_button.setHidden(True)
         
         self.stop_button = qt.QPushButton('STOP (Hold Esc)')
         self.stop_button.setMaximumWidth(util.scale_dpi(110))
-        self.stop_button.setMinimumHeight(30)
+        self.stop_button.setMinimumHeight(height)
         self.stop_button.hide()
         
         self.continue_button = qt.QPushButton('CONTINUE')
         self.continue_button.setMaximumWidth(util.scale_dpi(120))
-        self.continue_button.setMinimumHeight(30)
+        self.continue_button.setMinimumHeight(height)
         self.continue_button.hide()
         
         
@@ -449,6 +454,7 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
         self.settings_widget.code_text_size_changed.connect(self.code_widget.code_text_size_changed)
         self.settings_widget.code_expanding_tab_changed.connect(self._update_code_expanding_tab)
         self.settings_widget.data_expanding_tab_changed.connect(self._update_data_expanding_tab)
+        self.settings_widget.data_sidebar_visible_changed.connect(self._update_data_sidebar)
         
     def _update_code_expanding_tab(self, value):
         log.info('Updated code expanding tab %s' % value)
@@ -457,6 +463,10 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
     def _update_data_expanding_tab(self, value):
         log.info('Updated data expanding tab %s' % value)
         self._data_expanding_tab = value
+        
+    def _update_data_sidebar(self, value):
+        log.info('Updated data sidebar %s' % value)
+        self.data_widget.set_sidebar_visible(value)
            
     def resizeEvent(self, event):
         log.info('Resize')
@@ -987,7 +997,8 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
         sizes = self.process_splitter.sizes()
         
         if sizes[0] == 0 and sizes[1] > 0:
-            self._splitter_to_half()
+            self.process_splitter.setSizes([1,1])
+            #self._splitter_to_half()
             
         if sizes[0] > 1 and sizes[1] >= 0:
             self._full_tabs()

--- a/python/vtool/process_manager/ui_settings.py
+++ b/python/vtool/process_manager/ui_settings.py
@@ -14,6 +14,7 @@ class SettingsWidget(qt_ui.BasicWindow):
     code_text_size_changed = qt_ui.create_signal(object)
     code_expanding_tab_changed = qt_ui.create_signal(object)
     data_expanding_tab_changed = qt_ui.create_signal(object)
+    data_sidebar_visible_changed = qt_ui.create_signal(object)
     
     title = 'Process Settings'
     
@@ -24,6 +25,7 @@ class SettingsWidget(qt_ui.BasicWindow):
         self.code_directories = []
         self.template_history = []
         self.settings = None
+        self.setWindowFlags(qt.QtCore.Qt.WindowStaysOnTopHint)
         
     def sizeHint(self):
         return qt.QtCore.QSize(550,600)
@@ -84,6 +86,7 @@ class SettingsWidget(qt_ui.BasicWindow):
         
         self.data_tab_group = DataTabGroup()
         self.data_tab_group.data_expanding_tab_changed.connect(self.data_expanding_tab_changed)
+        self.data_tab_group.data_sidebar_visible_changed.connect(self.data_sidebar_visible_changed)
         
         self.options_widget.main_layout.addWidget(self.data_tab_group)
         
@@ -335,6 +338,7 @@ class IntSettingWidget(SettingWidget):
     
     def _build_signals(self):
         self.widget.valueChanged.connect(self.set_setting)
+        
     
     def set_value(self, value):
         self.widget.set_value(value)
@@ -362,6 +366,7 @@ class BoolSettingWidget(SettingWidget):
 class DataTabGroup(SettingGroup):
     
     data_expanding_tab_changed = qt.create_signal(object)
+    data_sidebar_visible_changed = qt.create_signal(object)
     group_title = 'Data Tab'
     
     def __init__(self):
@@ -382,10 +387,17 @@ class DataTabGroup(SettingGroup):
         sidebar_visible = BoolSettingWidget('Side Bar Visible', 'side bar visible')
         self.add_setting(sidebar_visible)
         sidebar_visible.set_value(1)
+        sidebar_visible.changed.connect(self._set_side_bar)
+        self.sidebar_visible = sidebar_visible
+        
     
     def _set_expand_tab(self):
         value = self.expand_tab.get_value()
         self.data_expanding_tab_changed.emit(value)
+        
+    def _set_side_bar(self):
+        value = self.sidebar_visible.get_value()
+        self.data_sidebar_visible_changed.emit(value)
     
 class CodeTabGroup(SettingGroup):
     
@@ -408,6 +420,9 @@ class CodeTabGroup(SettingGroup):
         self.editor_directory_widget.set_label('External Editor')
         
         self.code_text_size = IntSettingWidget('Code Text Size', 'code text size')
+        
+        self.code_text_size.widget.number_widget.setMinimum(14)
+        self.code_text_size.widget.number_widget.setMaximum(23)
         self.code_text_size.set_value(8)
         self.code_text_size.changed.connect(self.code_text_size_changed)
         self.add_setting(self.code_text_size)
@@ -448,6 +463,7 @@ class CodeTabGroup(SettingGroup):
         self.main_layout.addWidget(self.open_external)
         self.main_layout.addSpacing(12)
         
+        self.main_layout.addWidget(qt.QLabel('Code Text Size has limits\nMinimum: 14\nMaximum: 23'))
         self.main_layout.addWidget(self.code_text_size)
         self.main_layout.addWidget(self.pop_save)
         

--- a/python/vtool/process_manager/ui_settings.py
+++ b/python/vtool/process_manager/ui_settings.py
@@ -373,7 +373,6 @@ class DataTabGroup(SettingGroup):
         super(DataTabGroup, self).__init__(self.group_title)
         
     def _build_widgets(self):
-        label = qt.QLabel('Please reopen the ui for this setting to take effect')
         
         expand_label = qt.QLabel('Expand Splitter When Data Tab Selected')
         self.expand_tab = BoolSettingWidget('Expand Tab', 'data expanding tab')
@@ -381,8 +380,6 @@ class DataTabGroup(SettingGroup):
         self.add_setting(self.expand_tab)
         self.main_layout.addSpacing(util.scale_dpi(10))
         self.expand_tab.changed.connect(self._set_expand_tab)
-        
-        self.main_layout.addWidget(label)
         
         sidebar_visible = BoolSettingWidget('Side Bar Visible', 'side bar visible')
         self.add_setting(sidebar_visible)


### PR DESCRIPTION
The setting for the data sidebar visibility no longer requires a restart
Code Text Size now has a limit to reflect the limits of PySide QFont