### PR TITLE
Improvement: Settings directory and project history, dockable settings

### DIFF
--- a/install/userSetup.py
+++ b/install/userSetup.py
@@ -3,20 +3,14 @@
 
 #1 Add the lines below to your Maya userSetup.py. It should be found in user/Documents/maya/scripts.  
 #2 If it's not there, then add this file (userSetup.py) to that directory.
-
-#3 code_directory must be set to the directory where you installed Vetala. This can be anywhere you chose. The default path is set below.
-code_directory = 'C:/Program Files (x86)/Vetala' #<-- change only this path, make sure to include quotes. 
-
-
-#Please don't change any of the following unless you know how it works.
 import sys
+#update this path to the directory where vtool lives on your system
+sys.path.append('path/to/vtool/python/')
+
 import maya.utils
+from vtool.maya_lib import ui
 
-sys.path.append(code_directory)
-
-def run_tools_ui(directory = None):
-
-    from vtool.maya_lib import ui
-    ui.tool_manager(directory = directory)
+def run_tools_ui():
+    ui.tool_manager(name = 'VETALA HUB', directory = '')
 
 maya.utils.executeDeferred(run_tools_ui)

--- a/python/vtool/maya_lib/ui.py
+++ b/python/vtool/maya_lib/ui.py
@@ -57,17 +57,20 @@ def tool_manager(name = None, directory = None):
     """
     This command launches the Vetala Hub UI that hosts many different UIs
     """
-    workspace_name = ToolManager.title + 'WorkspaceControl'
+    
+    title = ToolManager.title
+    if name:
+        title = name
+    workspace_name =title + 'WorkspaceControl'
+    
     ui_core.delete_workspace_control(workspace_name)
     
     manager = ToolManager(name)
     
-    workspace_control = manager.title + 'WorkspaceControl'
-    
     if not ui_core.was_floating(manager.title):
         tab_name = ui_core.get_stored_tab(manager.title)
         manager.show()
-        ui_core.add_tab(workspace_control, tab_name)
+        ui_core.add_tab(workspace_name, tab_name)
     else:
         manager.show()
         
@@ -81,11 +84,19 @@ def process_manager(directory = None):
     This command launches the process manager which lists processes, their data and code. 
     """
     ui_core.delete_workspace_control(ui_rig.ProcessMayaWindow.title + 'WorkspaceControl')
-    window = ui_rig.ProcessMayaWindow()
+    window = ui_rig.ProcessMayaWindow(load_settings=True)
     
     if directory:
         window.set_directory(directory)
     
+    window.show()
+    
+    return window
+
+def process_manager_settings():
+    ui_core.delete_workspace_control(ui_rig.ProcessMayaSettingsWindow.title + 'WorkspaceControl')
+    window = ui_rig.ProcessMayaSettingsWindow()
+
     window.show()
     
     return window
@@ -117,6 +128,7 @@ class ToolManager(ui_core.MayaDirectoryWindowMixin):
     def __init__(self,name = None):
         
         if name:
+            ToolManager.title = name
             self.title = name
         
         self.default_docks = []

--- a/python/vtool/maya_lib/ui_core.py
+++ b/python/vtool/maya_lib/ui_core.py
@@ -278,7 +278,8 @@ class MayaDockMixin(MayaQWidgetDockableMixin):
                                         retain = False,
                                         restore = False)
         
-        cmds.workspaceControl(self.get_name(), e=True ,  mw=420)
+        if cmds.workspaceControl(self.get_name(), q=True, exists=True):
+            cmds.workspaceControl(self.get_name(), e=True ,  mw=420)
     
         self.raise_()
 

--- a/python/vtool/maya_lib/ui_lib/ui_rig.py
+++ b/python/vtool/maya_lib/ui_lib/ui_rig.py
@@ -27,6 +27,7 @@ from . import ui_model
 from . import ui_anim
 
 from ...process_manager import ui_process_manager
+from ...process_manager import ui_settings
 from ...ramen.ui_lib import ui_nodes
 from ...script_manager import script_view
 
@@ -82,11 +83,17 @@ def picker():
 def process_manager(directory = None):
     
     ui_core.delete_workspace_control(ProcessMayaWindow.title + 'WorkspaceControl')
-    
     window = ProcessMayaWindow(load_settings = False)
     
     if directory:
-        window.set_directory(directory, load_as_project=True)
+        window.set_directory(directory)
+    
+    window.show()
+    return window
+
+def process_manager_settings():
+    ui_core.delete_workspace_control(ProcessMayaSettingsWindow.title + 'WorkspaceControl')
+    window = ProcessMayaSettingsWindow()
     
     window.show()
     
@@ -102,6 +109,11 @@ class ProcessMayaWindow(ui_core.MayaDockMixin,ui_process_manager.ProcessManagerW
     title = 'VETALA'
     def __init__(self, load_settings = False):
         super(ProcessMayaWindow, self).__init__( load_settings= load_settings)
+
+class ProcessMayaSettingsWindow(ui_core.MayaDockMixin, ui_settings.SettingsWidget):
+    title = 'VETALA Settings'
+    def __init__(self):
+        super(ProcessMayaSettingsWindow, self).__init__()
 
 class RamenMayaWindow(ui_core.MayaDockMixin, ui_nodes.NodeWindow ):
     title = 'RAMEN'
@@ -250,6 +262,7 @@ class RigManager(qt_ui.DirectoryWindow):
         
     def _process_manager(self):
         window = process_manager(self.directory)
+        
         ui_core.emit_new_tool_signal(window)
 
     def _shape_combo(self):
@@ -590,8 +603,6 @@ class StructureWidget(RigWidget):
         
         if not selection:
             core.print_warning('Please select joints to add orient to.')
-            
-        
         
         attr.add_orient_attributes(selection, context_sensitive=True)
         core.print_help('Added orient attributes to the selected joints.')

--- a/python/vtool/process_manager/ui_settings.py
+++ b/python/vtool/process_manager/ui_settings.py
@@ -38,7 +38,10 @@ class SettingsWidget(qt_ui.BasicWindow):
         
         self.setContentsMargins(1,1,1,1)
         
+        self.hint = qt.QLabel('Hit the Settings Button in Vetala to see settings.')
+        
         self.tab_widget = qt.QTabWidget()
+        self.tab_widget.hide()
         
         self.dir_widget = qt_ui.BasicWidget()
         
@@ -60,6 +63,7 @@ class SettingsWidget(qt_ui.BasicWindow):
         self.tab_widget.addTab(self.template_directory_widget, 'Template')
         
         self.main_layout.addWidget(self.tab_widget)
+        self.main_layout.addWidget(self.hint)
         
     def _build_option_widgets(self):
         
@@ -150,6 +154,9 @@ class SettingsWidget(qt_ui.BasicWindow):
         self.code_tab_group.set_settings(settings)
         self.data_tab_group.set_settings(settings)
         self.template_directory_widget.set_settings(settings)
+        
+        self.tab_widget.show()
+        self.hint.hide()
         
     def refresh_template_list(self):
         

--- a/python/vtool/process_manager/ui_settings.py
+++ b/python/vtool/process_manager/ui_settings.py
@@ -18,14 +18,13 @@ class SettingsWidget(qt_ui.BasicWindow):
     
     title = 'Process Settings'
     
-    def __init__(self):
+    def __init__(self, parent = None):
         
-        super(SettingsWidget, self).__init__()
+        super(SettingsWidget, self).__init__(parent = parent)
         
         self.code_directories = []
         self.template_history = []
         self.settings = None
-        self.setWindowFlags(qt.QtCore.Qt.WindowStaysOnTopHint)
         
     def sizeHint(self):
         return qt.QtCore.QSize(550,600)
@@ -150,9 +149,6 @@ class SettingsWidget(qt_ui.BasicWindow):
         self.deadline_group.set_settings(settings)
         self.code_tab_group.set_settings(settings)
         self.data_tab_group.set_settings(settings)
-        
-    def set_template_settings(self, settings):
-        
         self.template_directory_widget.set_settings(settings)
         
     def refresh_template_list(self):
@@ -1037,8 +1033,6 @@ class ProjectDirectoryWidget(qt_ui.GetDirectoryWidget):
         if history:
             if not current_directory in history:
                 history.insert(0, current_directory)
-                
-        
         
         if self.settings:
             self.settings.set(self.history_entry, history)
@@ -1067,6 +1061,10 @@ class ProjectDirectoryWidget(qt_ui.GetDirectoryWidget):
         
         self.settings = settings
         self.list.set_settings(settings)
+        history = self.settings.get(self.history_entry)
+        directory = self.settings.get(self.directory_entry)
+        self.list.refresh_list(directory, history)
+        
 
 class ProjectList(qt.QTreeWidget):
 

--- a/python/vtool/process_manager/ui_settings.py
+++ b/python/vtool/process_manager/ui_settings.py
@@ -39,6 +39,11 @@ class SettingsWidget(qt_ui.BasicWindow):
         self.setContentsMargins(1,1,1,1)
         
         self.hint = qt.QLabel('Hit the Settings Button in Vetala to see settings.')
+        self.browse = qt.QPushButton('Browse')
+        self.browse.clicked.connect(self._open_browser)
+        self.browse.hide()
+        self.browse.setMaximumWidth(util.scale_dpi(70))
+        self.browse.setMaximumHeight(util.scale_dpi(20))
         
         self.tab_widget = qt.QTabWidget()
         self.tab_widget.hide()
@@ -62,6 +67,9 @@ class SettingsWidget(qt_ui.BasicWindow):
         #self.tab_widget.addTab(self.code_directory_widget, 'External Code')
         self.tab_widget.addTab(self.template_directory_widget, 'Template')
         
+        self.main_layout.addSpacing(util.scale_dpi(5))
+        self.main_layout.addWidget(self.browse, alignment = qt.QtCore.Qt.AlignRight)
+        self.main_layout.addSpacing(util.scale_dpi(5))
         self.main_layout.addWidget(self.tab_widget)
         self.main_layout.addWidget(self.hint)
         
@@ -115,6 +123,11 @@ class SettingsWidget(qt_ui.BasicWindow):
     def _code_directory_changed(self, code_directory):
         self.code_directory_changed.emit(code_directory)
     
+    def _open_browser(self):
+        filepath = self.settings.filepath
+        
+        util_file.open_browser( util_file.get_dirname(filepath) )
+    
     def get_project_directory(self):
         return self.project_directory_widget.get_directory()
         
@@ -156,6 +169,7 @@ class SettingsWidget(qt_ui.BasicWindow):
         self.template_directory_widget.set_settings(settings)
         
         self.tab_widget.show()
+        self.browse.show()
         self.hint.hide()
         
     def refresh_template_list(self):

--- a/python/vtool/util_file.py
+++ b/python/vtool/util_file.py
@@ -2292,6 +2292,7 @@ def fix_slashes(directory):
         return
     
     directory = directory.replace('\\','/')
+    directory = directory.replace('//','/')
     
     return directory
 


### PR DESCRIPTION
I'm updating refactoring a little the functionality when loading vetala
The following code will be valid once the branch is merged
```
ui.tool_manager(directory = 'E:/temp/vetala_project/')
ui.tool_manager('Hub UI Name', directory = 'E:/temp/vetala_project/')
#these will have vetala settings load to the specific directory.  I think this will be useful for testing. Easier to keep your work separate from your test environment.
#the default has always been something like
#C:\Users\Louis Vottero\Documents\process_manager\project
#now this can be customized

window = ui.process_manager('E:/temp/vetala_project/')
#This launches the process manager with base directory for settings set to the path specified. This is pretty much the same as the lines above, except that you have a handle on the process window.

window.set_project_directory('C:/Users/Louis Vottero/Documents/process_manager', 'test')
#With a handle on the process window you can then set your projects.

#If you are setting up environments for artists, these commands can help alot. As you can now setup projects that artists should have access too, etc
#The projects you set will be visible in the settings project history
``` 
Also the settings widget will now be dockable, which will help avoid it obscuring file dialogs and freezing Maya