### PR TITLE
Fix: corrective set translate on joints error

### DIFF
--- a/python/vtool/maya_lib/corrective.py
+++ b/python/vtool/maya_lib/corrective.py
@@ -3322,7 +3322,10 @@ class PoseCone(PoseBase):
             
             if cmds.objExists('%s.origTranslate' % joint):
                 translate = cmds.getAttr('%s.origTranslate' % joint)[0]
-                cmds.setAttr('%s.translate' % joint, *translate)
+                try:
+                    cmds.setAttr('%s.translate' % joint, *translate)
+                except:
+                    pass
                 
             else:
                 cmds.addAttr(joint, ln = 'origTranslate', at = 'double3')


### PR DESCRIPTION
This would cause an error to happen if joints were locked or connected.  Now it just skips over if they are locked or connected. 