### PR TITLE
Fix: copying directories in linux

### DIFF
--- a/python/vtool/util_file.py
+++ b/python/vtool/util_file.py
@@ -2633,7 +2633,10 @@ def fast_copy(directory, directory_destination):
 
     cmd=None
     if linux:
-        directory_destination = get_dirname(directory_destination)        
+        source_name = get_basename(directory)
+        destination_name = get_basename(directory_destination)
+        if source_name == destination_name:
+            directory_destination = get_dirname(directory_destination)        
         if not os.path.isdir(directory_destination):
             os.makedirs(directory_destination)
         #cmd = ['rsync', directory, directory_destination, '-ar']


### PR DESCRIPTION
It seems the copy command in linux works like this
when copying first to second using cp in linux

first = /my/path/my_folder
second = /my/other_path/my_folder

the result in linux:  /my/other_path/my_folder/my_folder
the result in windows: /my/other_path/my_folder

however if 
first = /my/path/my_folder
second = /my/other_path/my_folder/version

the result in linux: /my/other_path/my_folder/version
the result in windows: /my/other_path/my_folder/version

in order to have linux work like windows, I check to see if the folder name being copied to is the same, and then copy to the parent folder instead if the names are the same. 

