### PR TITLE
Instance attribute fixes 11 06 2023

### DIFF
--- a/python/vtool/data.py
+++ b/python/vtool/data.py
@@ -388,6 +388,7 @@ class FileData(Data):
 
     def __init__(self, name=None):
         super(FileData, self).__init__(name)
+        self.filepath = None
         self.directory = None
         self.settings = util_file.SettingsFile()
         self.file = None
@@ -524,6 +525,10 @@ class FileData(Data):
 
 
 class ScriptData(FileData):
+
+    def __init__(self, name=None):
+        super(ScriptData, self).__init__(name)
+        self.lines = None
 
     def save(self, lines, comment=None):
 
@@ -2451,6 +2456,7 @@ class AnimationData(MayaCustomData):
     def __init__(self, name=None):
         super(AnimationData, self).__init__(name)
 
+        self.selection = None
         self.namespace = ''
 
     def _data_name(self):

--- a/python/vtool/maya_lib/api.py
+++ b/python/vtool/maya_lib/api.py
@@ -1822,6 +1822,7 @@ def set_skin_weights(skin_cluster, weights=0, index=0, components=None, influenc
         if not isinstance(weights, list) and not isinstance(weights, tuple):
             weight_array = om.MDoubleArray()
 
+            # TODO: Potential bug here, we are checking the above to determine that it is not a list or a tuple, yet trying to iterate.
             for weight in weights:
                 weight_array.append(float(weights))
 

--- a/python/vtool/maya_lib/corrective.py
+++ b/python/vtool/maya_lib/corrective.py
@@ -55,6 +55,7 @@ class PoseManager(object):
     """
 
     def __init__(self):
+        self.pose_control = None
         self.poses = []
         self._namespace = None
 
@@ -2591,6 +2592,11 @@ class PoseNoReader(PoseBase):
     This type of pose does not read anything in a rig unless an input is specified.
     """
 
+    def __init__(self, description='pose'):
+        super(PoseNoReader, self).__init__(description)
+        self.other_pose_exists = None
+        self.weight_input = None
+
     def _pose_type(self):
         return 'no reader'
 
@@ -3159,6 +3165,7 @@ class PoseCone(PoseBase):
     def __init__(self, transform=None, description='pose'):
         super(PoseCone, self).__init__(description)
 
+        self.other_pose_exists = None
         if transform:
             transform = transform.replace(' ', '_')
 

--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -126,6 +126,7 @@ class XformTransfer(object):
 
     def __init__(self, ):
 
+        self.scope = None
         self.source_mesh = None
         self.target_mesh = None
         self.particles = None
@@ -901,6 +902,8 @@ class SplitMeshTarget(object):
 
     def __init__(self, target_mesh):
 
+        self.base_mesh_count = None
+        self.base_meshes = None
         self.target_mesh = util.convert_to_sequence(target_mesh)
 
         self.weighted_mesh = None
@@ -3789,6 +3792,7 @@ class ZipWire2(object):
 
     def __init__(self, mesh, follow_curve_top, follow_curve_btm):
 
+        self.setup_group = None
         self._mesh = mesh
         self._top_curve = follow_curve_top
         self._btm_curve = follow_curve_btm

--- a/python/vtool/maya_lib/geo.py
+++ b/python/vtool/maya_lib/geo.py
@@ -48,7 +48,19 @@ class MeshTopologyCheck(object):
 
     def __init__(self, mesh1, mesh2=None):
 
+
+        self.mesh1_face_count = None
+        self.mesh1_edge_count = None
+        self.mesh1_vert_count = None
+        self.mesh1_function = None
+        self.mesh1 = None
         self.set_first_mesh(mesh1)
+
+        self.mesh2_face_count = None
+        self.mesh2_edge_count = None
+        self.mesh2_vert_count = None
+        self.mesh2_function = None
+        self.mesh2 = None
         if mesh2:
             self.set_second_mesh(mesh2)
 

--- a/python/vtool/maya_lib/rigs.py
+++ b/python/vtool/maya_lib/rigs.py
@@ -981,6 +981,7 @@ class JointRig(Rig):
     def __init__(self, description, side=None):
         super(JointRig, self).__init__(description, side)
 
+        self._switch_shape_node_name = None
         self.joints = []
 
         self.attach_joints = True
@@ -1097,6 +1098,7 @@ class BufferRig(JointRig):
     def __init__(self, name, side=None):
         super(BufferRig, self).__init__(name, side)
 
+        self._switch_shape_node_name = None
         self.create_buffer_joints = False
         self.build_hierarchy = False
         self._buffer_replace = ['joint', 'buffer']
@@ -1264,6 +1266,7 @@ class SurfaceRig(Rig):
     def __init__(self, description, side=None):
         super(SurfaceRig, self).__init__(description, side)
 
+        self.surfaces = None
         self.curves = None
 
     def set_surface(self, surface_list):
@@ -1288,6 +1291,8 @@ class SparseRig(JointRig):
     def __init__(self, description, side=None):
         super(SparseRig, self).__init__(description, side)
 
+        self.current_inc = None
+        self.respect_side_offset = None
         self.control_shape = 'cube'
         self.is_scalable = False
         self.respect_side = False
@@ -2885,6 +2890,7 @@ class FkCurlRig(FkScaleRig):
     def __init__(self, description, side=None):
         super(FkCurlRig, self).__init__(description, side)
 
+        self.attribute_name = None
         self.attribute_control = None
         self.curl_axis = 'Z'
         self.curl_description = self.description
@@ -4288,6 +4294,10 @@ class IkSplineNubRig(BufferRig):
 
         super(IkSplineNubRig, self).__init__(description, side)
 
+        self.btm_xform = None
+        self.btm_control = None
+        self.top_xform = None
+        self.top_control = None
         self.end_with_locator = False
         self.top_guide = None
         self.btm_guide = None
@@ -4693,6 +4703,7 @@ class IkAppendageRig(BufferRig):
     def __init__(self, description, side=None):
         super(IkAppendageRig, self).__init__(description, side)
 
+        self.top_control = None
         self.right_side_fix = True
         self._ik_buffer_joint = True
         self.create_twist = True
@@ -5578,6 +5589,7 @@ class TweakCurveRig(BufferRig):
     def __init__(self, name, side=None):
         super(TweakCurveRig, self).__init__(name, side)
 
+        self.maya_type = None
         self.control_count = 4
         self.curve = None
         self.surface = None
@@ -5926,6 +5938,10 @@ class RopeRig(CurveRig):
 class ConvertJointToNub(object):
 
     def __init__(self, name, side='C'):
+        self.btm_xform = None
+        self.top_xform = None
+        self.btm_control = None
+        self.top_control = None
         self.start_joint = None
         self.end_joint = None
         self.count = 10
@@ -6131,6 +6147,7 @@ class TwistRig(JointRig):
     def __init__(self, name, side=None):
         super(TwistRig, self).__init__(name, side)
 
+        self.twist_group = None
         self.control_count = 5
         self._offset_axis = 'Y'
         self._attach_directly = True
@@ -6398,6 +6415,7 @@ class SpineRig(BufferRig, SplineRibbonBaseRig):
 
         super(SpineRig, self).__init__(description, side)
 
+        self.bottom_color = None
         self.tweak_control_count = 2
         self.control_count = 1
         self.forward_fk = True
@@ -7306,6 +7324,8 @@ class IkScapulaRig(BufferRig):
 
     def __init__(self, description, side=None):
 
+        self._scapula_rotate_axis = None
+        self._arm_rotate_axis = None
         self.control_shape = 'square'
 
         super(IkScapulaRig, self).__init__(description, side)
@@ -8535,6 +8555,9 @@ class FootRig(BaseFootRig):
     def __init__(self, description, side=None):
         super(FootRig, self).__init__(description, side)
 
+        self.toe = None
+        self.ball = None
+        self.ankle = None
         self.build_hierarchy = True
 
         self.toe_rotate_as_locator = False
@@ -9204,6 +9227,8 @@ class QuadFootRig(FootRig):
     def __init__(self, description, side=None):
         super(QuadFootRig, self).__init__(description, side)
 
+        self.ball = None
+        self.toe = None
         self.ball_attribute = None
         self.add_bank = True
         self.add_back_bank = False
@@ -10045,6 +10070,8 @@ class StickyRig(JointRig):
     def __init__(self, description, side=None):
         super(StickyRig, self).__init__(description, side)
 
+        self.top_stick_values = None
+        self.btm_stick_values = None
         self.top_joints = []
         self.btm_joints = []
         self.respect_side = True
@@ -10844,6 +10871,7 @@ class StickyFadeRig(StickyRig):
 class EyeRig(JointRig):
     def __init__(self, description, side=None):
         super(EyeRig, self).__init__(description, side)
+        self._fk_control_shape = None
         self.local_parent = None
         self.parent = None
 
@@ -11149,6 +11177,8 @@ class JawRig(FkLocalRig):
 class LipRig(JointRig):
     def __init__(self, description, side=None):
         super(LipRig, self).__init__(description, side)
+        self.parameters = None
+        self.param_control_dict = None
 
     def _create_curve(self):
 
@@ -11774,6 +11804,7 @@ class FeatherStripRig(CurveRig):
 
         super(FeatherStripRig, self).__init__(description, side)
 
+        self.geo_group = None
         self.curve_controls = []
 
         self.feather_count = 10
@@ -12424,6 +12455,8 @@ class FeatherOnPlaneRig(PolyPlaneRig):
     def __init__(self, description, side):
         super(FeatherOnPlaneRig, self).__init__(description, side)
 
+        self.smooth_surface = None
+        self.smooth_center = None
         self._quill_radius = 0.5
         self._follow_u = True
         self._feather_count = 5

--- a/python/vtool/maya_lib/rigs_dev.py
+++ b/python/vtool/maya_lib/rigs_dev.py
@@ -369,6 +369,8 @@ class StickyRig(rigs.JointRig):
     def __init__(self, description, side):
         super(StickyRig, self).__init__(description, side)
 
+        self.btm_stick_values = None
+        self.top_stick_values = None
         self.top_joints = []
         self.btm_joints = []
         self.respect_side = True
@@ -1794,6 +1796,8 @@ class CurveAndSurfaceRig(rigs.BufferRig):
 
     def __init__(self, description, side):
         super(CurveAndSurfaceRig, self).__init__(description, side)
+        self.no_follow_curve = None
+        self.curve = None
         self.span_count = 4
         self.surface = None
         self.clusters = []
@@ -2852,6 +2856,8 @@ class WorldStickyRig(rigs.JointRig):
     def __init__(self, description, side):
         super(WorldStickyRig, self).__init__(description, side)
 
+        self.btm_stick_values = None
+        self.top_stick_values = None
         self.top_joints = []
         self.btm_joints = []
         self.respect_side = True
@@ -4577,6 +4583,7 @@ class SimpleBackLeg(rigs.BufferRig):
     def __init__(self, description, side):
         super(SimpleBackLeg, self).__init__(description, side)
 
+        self.group_main_ik = None
         self.pole_offset = 5
         self.create_sub_control = True
 

--- a/python/vtool/maya_lib/rigs_old.py
+++ b/python/vtool/maya_lib/rigs_old.py
@@ -779,6 +779,7 @@ class SingleControlFaceCurveRig(FaceFollowCurveRig):
     def __init__(self, description, side):
         super(SingleControlFaceCurveRig, self).__init__(description, side)
 
+        self.curve_shape = None
         self.attach_surface = None
         self.curve_position_percent = 0
         self.shape_name = 'pin'

--- a/python/vtool/maya_lib/rigs_util.py
+++ b/python/vtool/maya_lib/rigs_util.py
@@ -940,6 +940,7 @@ class StretchyChain:
     """
 
     def __init__(self):
+        self.joints = None
         self.side = 'C'
         self.inputs = []
         self.attribute_node = None
@@ -1375,6 +1376,7 @@ class StretchyElbowLock(object):
             three_controls (list): For example the top arm control, the pole vector control and the btm control.
                 Controls should transform that correspond to an ik setup.
         """
+        self._parent = None
         self.joints = three_joints
         self.controls = three_controls
         self.axis_letter = 'X'
@@ -1653,6 +1655,9 @@ class SoftIk(object):
 
     def __init__(self, joints):
 
+        self.description = None
+        self._ik_locator_parent = None
+        self._default_distance_attribute = None
         self._joints = joints
         self._attribute_control = None
         self._control_distance_attribute = None
@@ -2132,6 +2137,10 @@ class TwistRibbon(object):
         Takes a joint.
         If no end_transform given, the code will take the first child of the joint as the end of the ribbon.
         """
+        self.btm_joint = None
+        self.top_joint = None
+        self.surface_stretch_curve_node = None
+        self.surface_stretch_curve = None
         self.joints = []
         self.rivets = []
         self.control_xforms = []

--- a/python/vtool/maya_lib/space.py
+++ b/python/vtool/maya_lib/space.py
@@ -24,6 +24,9 @@ if util.in_maya:
 
 class VertexOctree(object):
 
+    def __init__(self):
+        self.top_node = None
+
     def _get_bounding_box(self, mesh):
         bounding_box = cmds.exactWorldBoundingBox(mesh)
         center = cmds.objectCenter(mesh, gl=True)
@@ -907,6 +910,7 @@ class OrientJoint(object):
 
     def __init__(self, joint_name, children=None):
 
+        self.has_grand_child = None
         if children is None:
             children = []
         self.joint = joint_name
@@ -1837,6 +1841,7 @@ class BuildHierarchy(object):
 class OverDriveTranslation(object):
 
     def __init__(self, transform, driver):
+        self.y_values = None
         self.transform = transform
         self.driver = driver
 

--- a/python/vtool/maya_lib/ui_lib/ui_corrective.py
+++ b/python/vtool/maya_lib/ui_lib/ui_corrective.py
@@ -175,6 +175,7 @@ class PoseListWidget(qt_ui.BasicWidget):
     pose_mirror_all = qt_ui.create_signal()
 
     def __init__(self, shot_sculpt_only):
+        self.skip_name_filter = None
         self.shot_sculpt_only = shot_sculpt_only
 
         super(PoseListWidget, self).__init__()
@@ -377,6 +378,7 @@ class BaseTreeWidget(qt_ui.TreeWidget):
 
     def __init__(self):
 
+        self.last_selection = None
         self.edit_state = False
         super(BaseTreeWidget, self).__init__()
         self.setSortingEnabled(True)
@@ -533,6 +535,8 @@ class PoseTreeWidget(BaseTreeWidget):
 
     def __init__(self, shot_sculpt_only=False):
 
+        self.dragged_item = None
+        self.drag_parent = None
         self.shot_sculpt_only = shot_sculpt_only
         self.item_context = []
         self.context_menu_item = None
@@ -2255,6 +2259,7 @@ class PoseComboList(qt_ui.BasicWidget):
     def __init__(self):
         super(PoseComboList, self).__init__()
 
+        self.pose = None
         self.setSizePolicy(qt.QSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding))
 
         self.pose_widgets = []

--- a/python/vtool/maya_lib/ui_lib/ui_fx.py
+++ b/python/vtool/maya_lib/ui_lib/ui_fx.py
@@ -68,6 +68,7 @@ class CacheWidget(qt_ui.BasicWidget):
 
     def __init__(self):
         super(CacheWidget, self).__init__()
+        self.namespaces = None
         self.main_layout.setContentsMargins(10, 10, 10, 10)
 
     def _build_widgets(self):
@@ -245,6 +246,10 @@ class FxSettingsWidget(qt_ui.BasicWidget):
 
 
 class SettingWidget(qt_ui.BasicWidget):
+
+    def __init__(self, parent=None, scroll=False):
+        super(SettingWidget, self).__init__(parent, scroll)
+        self.namespace = None
 
     def _build_widgets(self):
         self.label = qt.QLabel()

--- a/python/vtool/maya_lib/ui_lib/ui_picker.py
+++ b/python/vtool/maya_lib/ui_lib/ui_picker.py
@@ -498,6 +498,7 @@ class ItemValues(qt_ui.BasicWidget):
     def __init__(self):
         super(ItemValues, self).__init__()
 
+        self.skip_update_values = None
         self.picker = None
 
     def _build_widgets(self):
@@ -649,6 +650,7 @@ class Picker(qt_ui.BasicGraphicsView):
 
         super(Picker, self).__init__()
 
+        self._zoom = None
         self.setDragMode(qt.QGraphicsView.ScrollHandDrag)
         self.setTransformationAnchor(self.AnchorUnderMouse)
         self.setVerticalScrollBarPolicy(qt.QtCore.Qt.ScrollBarAlwaysOff)

--- a/python/vtool/process_manager/process.py
+++ b/python/vtool/process_manager/process.py
@@ -293,6 +293,7 @@ class Process(object):
 
     def __init__(self, name=None):
 
+        self.runtime_values = None
         self._put = None
         self._put = None
         self._runtime_values = None

--- a/python/vtool/process_manager/process.py
+++ b/python/vtool/process_manager/process.py
@@ -293,6 +293,11 @@ class Process(object):
 
     def __init__(self, name=None):
 
+        self._put = None
+        self._put = None
+        self._runtime_values = None
+        self._data_override = None
+        self.option_settings = None
         log.debug('Initialize process %s' % name)
 
         self.directory = util_file.get_cwd()

--- a/python/vtool/process_manager/ui_code.py
+++ b/python/vtool/process_manager/ui_code.py
@@ -31,6 +31,8 @@ class CodeProcessWidget(qt_ui.DirectoryWidget):
 
     def __init__(self):
 
+        self.settings = None
+        self.code_directory = None
         self._process_inst = None
 
         super(CodeProcessWidget, self).__init__()
@@ -422,6 +424,7 @@ class CodeCompleter(qt_ui.PythonCompleter):
 
     def __init__(self):
         super(CodeCompleter, self).__init__()
+        self._put_list = None
 
     def keyPressEvent(self):
         return
@@ -810,6 +813,7 @@ class CodeManifestTree(qt_ui.FileTreeWidget):
 
         super(CodeManifestTree, self).__init__()
 
+        self.drag_parent = None
         self.process = None
 
         self.title_text_index = 0

--- a/python/vtool/process_manager/ui_data.py
+++ b/python/vtool/process_manager/ui_data.py
@@ -316,6 +316,7 @@ class DataWidget(qt_ui.BasicWidget):
     open_sub_folder = qt_ui.create_signal()
 
     def __init__(self, parent=None, scroll=False):
+        self.list = None
         self.file_widget = None
         super(DataWidget, self).__init__(parent, scroll)
 
@@ -1907,6 +1908,10 @@ class ScriptSaveFileWidget(qt_ui.SaveFileWidget):
 
 
 class ScriptHistoryFileWidget(qt_ui.HistoryFileWidget):
+
+    def __init__(self, parent=None, scroll=False):
+        super(ScriptHistoryFileWidget, self).__init__(parent, scroll)
+        self.text_widget = None
 
     def _open_version(self):
 

--- a/python/vtool/process_manager/ui_options.py
+++ b/python/vtool/process_manager/ui_options.py
@@ -1862,6 +1862,7 @@ class ProcessOption(qt_ui.BasicWidget):
 
     def __init__(self, name):
 
+        self.menu = None
         self.process_inst = None
         self.ref_path = None
 

--- a/python/vtool/process_manager/ui_process_maintenance.py
+++ b/python/vtool/process_manager/ui_process_maintenance.py
@@ -117,7 +117,9 @@ class PruneVersionsWidget(qt_ui.BasicWidget):
     
     def __init__(self):
         super(PruneVersionsWidget, self).__init__()
-        
+
+        self.process_inst = None
+        self.directory = None
         self._last_directory = None
     
     def _define_main_layout(self):

--- a/python/vtool/process_manager/ui_process_settings.py
+++ b/python/vtool/process_manager/ui_process_settings.py
@@ -43,6 +43,7 @@ class ProcessSettings(qt_ui.BasicWidget):
 class MayaOptions(qt_ui.Group):
 
     def __init__(self):
+        self.settings = None
         self._skip_set_value = False
         super(MayaOptions, self).__init__('Maya')
 

--- a/python/vtool/process_manager/ui_settings.py
+++ b/python/vtool/process_manager/ui_settings.py
@@ -187,7 +187,8 @@ class ProcessGroup(qt_ui.Group):
 
     def __init__(self):
         super(ProcessGroup, self).__init__('Process')
-        
+        self.settings = None
+
     def _build_widgets(self):
         
         
@@ -276,6 +277,7 @@ class ProcessGroup(qt_ui.Group):
 class SettingGroup(qt_ui.Group):     
     
     def __init__(self, name):
+        self.settings = None
         self._setting_insts = []
         super(SettingGroup, self).__init__(name)
         self.collapse_group()
@@ -543,7 +545,8 @@ class ShotgunGroup(qt_ui.Group):
     
     def __init__(self):
         super(ShotgunGroup, self).__init__('Shotgun Settings')
-    
+        self.settings = None
+
     def _build_widgets(self):
         super(ShotgunGroup,self)._build_widgets()
         
@@ -678,7 +681,8 @@ class DeadlineGroup(qt_ui.Group):
     
     def __init__(self):
         super(DeadlineGroup, self).__init__('Deadline Settings')
-    
+        self.settings = None
+
     def _build_widgets(self):
         super(DeadlineGroup,self)._build_widgets()
         
@@ -1096,7 +1100,8 @@ class ProjectList(qt.QTreeWidget):
 
     def __init__(self):
         super(ProjectList, self).__init__()
-        
+
+        self.history = None
         self.setAlternatingRowColors(True)
         if util.in_houdini:
             self.setAlternatingRowColors(False)        

--- a/python/vtool/process_manager/ui_templates.py
+++ b/python/vtool/process_manager/ui_templates.py
@@ -13,6 +13,15 @@ class TemplateWidget(qt_ui.BasicWidget):
     merge_template = qt_ui.create_signal(object, object)
     match_template = qt_ui.create_signal(object, object)
 
+    def __init__(self, parent=None, scroll=False):
+        super(TemplateWidget, self).__init__(parent, scroll)
+        self.active = None
+        self.settings = None
+        self.current = None
+        self.handle_current_change = None
+        self.template_dict = None
+        self.template_list = None
+
     def _build_widgets(self):
 
         title_layout = qt.QHBoxLayout()

--- a/python/vtool/qt_ui.py
+++ b/python/vtool/qt_ui.py
@@ -354,6 +354,7 @@ class TreeWidget(qt.QTreeWidget):
     def __init__(self):
         super(TreeWidget, self).__init__()
 
+        self.dropIndicatorPosition = None
         self._auto_add_sub_items = True
 
         self.title_text_index = 0
@@ -1941,6 +1942,10 @@ class HistoryTreeWidget(FileTreeWidget):
 class HistoryFileWidget(DirectoryWidget):
     file_changed = create_signal()
 
+    def __init__(self, parent=None, scroll=False):
+        super(HistoryFileWidget, self).__init__(parent, scroll)
+        self.data_class = None
+
     def _define_main_layout(self):
         return qt.QVBoxLayout()
 
@@ -2053,6 +2058,7 @@ class DictionaryWidget(BasicWidget):
 
     def __init__(self):
 
+        self._garbage_items = None
         self.order = []
         self.dictionary = {}
 
@@ -3402,6 +3408,7 @@ class CodeEditTabs(BasicWidget):
     def __init__(self):
         super(CodeEditTabs, self).__init__()
 
+        self._process_inst = None
         self.code_tab_map = {}
         self.code_floater_map = {}
         self.code_window_map = {}
@@ -5384,6 +5391,8 @@ class PythonCompleter(qt.QCompleter):
     def __init__(self):
         super(PythonCompleter, self).__init__()
 
+        self.filepath = None
+        self.info = None
         self.model_strings = []
 
         self.reset_list = True
@@ -6287,6 +6296,7 @@ class CompactHistoryWidget(BasicWidget):
     def __init__(self):
         super(CompactHistoryWidget, self).__init__()
 
+        self._auto_accept = None
         self.current_number = None
         self.version_inst = None
 
@@ -6938,6 +6948,7 @@ class SelectTreeItemDelegate(qt.QStyledItemDelegate):
 
     def __init__(self):
         super(SelectTreeItemDelegate, self).__init__()
+        self.text_offset = None
 
     def set_text_offset(self, value):
 

--- a/python/vtool/ramen/rigs.py
+++ b/python/vtool/ramen/rigs.py
@@ -134,6 +134,7 @@ class Attributes(object):
 
 class Base(object):
     def __init__(self):
+        self._uuid = None
         self._init_attribute()
 
         self._init_variables()

--- a/python/vtool/ramen/rigs_maya.py
+++ b/python/vtool/ramen/rigs_maya.py
@@ -23,6 +23,7 @@ class Control(object):
 
     def __init__(self, name):
 
+        self._color = None
         self._use_joint = False
 
         self.name = ''

--- a/python/vtool/ramen/ui_lib/ui_nodes.py
+++ b/python/vtool/ramen/ui_lib/ui_nodes.py
@@ -263,6 +263,10 @@ class NodeWindow(qt_ui.BasicGraphicsWindow):
 
 class NodeDirectoryWindow(NodeWindow):
 
+    def __init__(self, parent=None):
+        super(NodeDirectoryWindow, self).__init__(parent)
+        self.directory = None
+
     def set_directory(self, directory):
         self.directory = directory
         self.main_view.set_directory(directory)
@@ -273,6 +277,7 @@ class NodeView(qt_ui.BasicGraphicsView):
     def __init__(self, parent=None):
         super(NodeView, self).__init__(parent)
 
+        self.prev_position = None
         self._cache = None
         self._zoom = 1
         self._zoom_min = 0.1
@@ -589,6 +594,10 @@ class NodeView(qt_ui.BasicGraphicsView):
 
 
 class NodeViewDirectory(NodeView):
+    def __init__(self, parent=None):
+        super(NodeViewDirectory, self).__init__(parent)
+        self.directory = None
+
     def set_directory(self, directory):
 
         self._cache = None
@@ -1197,6 +1206,14 @@ class NodeSocket(qt.QGraphicsItem, BaseAttributeItem):
         super(NodeSocket, self).__init__()
         BaseAttributeItem.__init__(self)
 
+        self.new_line = None
+        self.lines = None
+        self.color = None
+        self.rect = None
+        self.side_socket_height = None
+        self.pen = None
+        self.brush = None
+        self.node_width = None
         self.dirty = True
 
         self._name = name
@@ -1490,6 +1507,7 @@ class NodeLine(qt.QGraphicsPathItem):
     def __init__(self, pointA=None, pointB=None):
         super(NodeLine, self).__init__()
 
+        self.color = None
         self._pointA = pointA
         self._pointB = pointB
         self._source = None
@@ -1678,6 +1696,12 @@ class NodeLine(qt.QGraphicsPathItem):
 
 class GraphicsItem(qt.QGraphicsItem):
     def __init__(self, parent=None):
+        self._left_over_space = None
+        self._current_socket_pos = None
+        self.brush = None
+        self.selPen = None
+        self.pen = None
+        self.rect = None
         self.node_width = self._init_node_width()
 
         super(GraphicsItem, self).__init__(parent)
@@ -1812,6 +1836,8 @@ class NodeItem(GraphicsItem):
     item_name = 'Node'
 
     def __init__(self, name='', uuid_value=None):
+        self.uuid = None
+        self._current_socket_pos = None
         self._dirty = None
 
         self._color = self._init_color()

--- a/python/vtool/util.py
+++ b/python/vtool/util.py
@@ -817,7 +817,7 @@ class Part(object):
         pass
 
 
-def convert_to_sequence(variable, sequence_type=list):
+def convert_to_sequence(variable, sequence_type=list):  # TODO: There are a ton of calls to this that dont need to exist if one just uses the respective literal.
     """
     Easily convert to a sequence. 
     If variable is already of sequence_type, pass it through.
@@ -830,7 +830,7 @@ def convert_to_sequence(variable, sequence_type=list):
     Args:
     
         variable: Any variable.
-        sequence_type: Can either be python list or python tuple. Needs to be the type ojbect, which means pass it list or tuple not as a string.
+        sequence_type: Can either be python list or python tuple. Needs to be the type object, which means pass it list or tuple not as a string.
         
     Returns:
         list, tuple: Returns list or tuple depending on the sequence_type.


### PR DESCRIPTION
These changes have been made to address rogue object attributes being initialized in methods rather than on initialization. While this isn't particularly terrible, its best practice to go back and specify them in the init statement, as to inform the developer of whats being potentially mutated, stored, and worked on.

This also tends to assist developers when debugging.