### PR TITLE
Conversion to list literals for calls to hide_attributes

### DIFF
--- a/python/vtool/maya_lib/attr.py
+++ b/python/vtool/maya_lib/attr.py
@@ -2353,8 +2353,6 @@ def hide_attributes(node, attributes):
         attributes (list): A list of attributes on node to lock and hide. Just the name of the attribute.
     """
 
-    attributes = util.convert_to_sequence(attributes)
-
     for attribute in attributes:
 
         current_attribute = ['%s.%s' % (node, attribute)]
@@ -2376,7 +2374,7 @@ def hide_keyable_attributes(node):
         node (str) The name of a node.
     """
 
-    attributes = cmds.listAttr(node, k=True)
+    attributes = cmds.listAttr(node, k=True)  # type: list
 
     if attributes:
         hide_attributes(node, attributes)
@@ -2384,22 +2382,22 @@ def hide_keyable_attributes(node):
     if cmds.getAttr('%s.rotateOrder' % node, cb=True):
         hide_rotate_order(node)
 
-
 def hide_translate(node):
-    hide_attributes(node, 'translate')
+    hide_attributes(node, ['translate'])
+
 
 
 def hide_rotate(node):
-    hide_attributes(node, 'rotate')
-    hide_attributes(node, 'rotateOrder')
+    hide_attributes(node, ['rotate'])
+    hide_attributes(node, ['rotateOrder'])
 
 
 def hide_scale(node):
-    hide_attributes(node, 'scale')
+    hide_attributes(node, ['scale'])
 
 
 def hide_visibility(node):
-    hide_attributes(node, 'visibility')
+    hide_attributes(node, ['visibility'])
 
 
 def lock_attributes(node, bool_value=True, attributes=None, hide=False):

--- a/python/vtool/maya_lib/rigs_util.py
+++ b/python/vtool/maya_lib/rigs_util.py
@@ -325,6 +325,9 @@ class Control(object):
 
             attributes (list): List of attributes, e.g. ['translateX', 'translateY']
         """
+        if attributes is None:
+            attributes = []
+
         if attributes:
             attr.hide_attributes(self.control, attributes)
 
@@ -338,9 +341,7 @@ class Control(object):
         Lock and hide the translation attributes on the control.
         """
 
-        attr.hide_attributes(self.control, ['translateX',
-                                            'translateY',
-                                            'translateZ'])
+        attr.hide_attributes(self.control, ['translateX', 'translateY', 'translateZ'])
 
     def hide_rotate_attributes(self):
         """
@@ -352,9 +353,7 @@ class Control(object):
         """
         Lock and hide the scale attributes on the control.
         """
-        attr.hide_attributes(self.control, ['scaleX',
-                                            'scaleY',
-                                            'scaleZ'])
+        attr.hide_attributes(self.control, ['scaleX', 'scaleY', 'scaleZ'])
 
     def hide_visibility_attribute(self):
         """


### PR DESCRIPTION
Calls to hide_attributes() were a mix of lists and strings. This irritated the type checker and is generally poor practice. 
Due to being a mixture of potential data types, strings would have to be converted to lists, before hide_attributes could continue processing.
These changes convert the standalone strings to list literals and rely on the type hints of hide_attributes to inform the user of what the correct types of input are. 
These changes should result in a small bump to performance.
