### PR TITLE
switching project fix, hide file widget when no directory

### DIFF
--- a/python/vtool/data.py
+++ b/python/vtool/data.py
@@ -83,6 +83,7 @@ class DataFolder(object):
         new_path = util_file.join_path(filepath, name)
         self.filepath = util_file.get_dirname(new_path)
         self.name = util_file.get_basename(new_path)
+        self.folder_path = None
 
         self.data_type = None
 
@@ -133,6 +134,8 @@ class DataFolder(object):
 
     def _create_folder(self):
 
+        if not self.name and not self.filepath:
+            return
         path = util_file.create_dir(self.name, self.filepath)
         self.folder_path = path
         self._set_default_settings()
@@ -359,6 +362,7 @@ class DataFile(object):
 
 
 class Data(object):
+
     def __init__(self, name=None):
         self.data_type = self._data_type()
         self.data_extension = self._data_extension()
@@ -594,6 +598,7 @@ class CustomData(FileData):
 
 
 class MayaCustomData(CustomData):
+
     def _center_view(self):
         # cmds.select(cl = True)
 
@@ -1879,6 +1884,7 @@ class SkinWeightData(MayaCustomData):
 
 
 class LoadWeightFileThread(threading.Thread):
+
     def __init__(self):
         super(LoadWeightFileThread, self).__init__()
 
@@ -1910,6 +1916,7 @@ class LoadWeightFileThread(threading.Thread):
 
 
 class ReadWeightFileThread(threading.Thread):
+
     def __init__(self, influence_dict, folder_path, influence):
         super(ReadWeightFileThread, self).__init__()
 
@@ -3840,6 +3847,7 @@ class MayaShotgunFileData(MayaFileData):
 
 
 class ContextData(CustomData):
+
     def _data_name(self):
         return 'context'
 
@@ -3851,6 +3859,7 @@ class ContextData(CustomData):
 
 
 class HoudiniFileData(CustomData):
+
     def _data_name(self):
         return 'houdini_file'
 
@@ -3862,6 +3871,7 @@ class HoudiniFileData(CustomData):
 
 
 class HoudiniNodeData(CustomData):
+
     def _data_name(self):
         return 'houdini_nodes'
 
@@ -3873,6 +3883,7 @@ class HoudiniNodeData(CustomData):
 
 
 class UnrealGraphData(CustomData):
+
     def _data_name(self):
         return 'unreal_graph'
 

--- a/python/vtool/process_manager/ui_data.py
+++ b/python/vtool/process_manager/ui_data.py
@@ -355,10 +355,15 @@ class DataWidget(qt_ui.BasicWidget):
         if not directory:
             folder = self.directory
 
+        if folder:
+            self.file_widget.show()
+        else:
+            self.file_widget.hide()
+
         if hasattr(self.file_widget, 'set_directory'):
             self.file_widget.set_directory(folder)
 
-        if hasattr(self.file_widget, 'set_temp_sub_folder'):
+        if hasattr(self.file_widget, 'set_temp_sub_folder') and folder:
             log.info('Setting temp sub folder: %s' % sub_folder)
             self.file_widget.set_temp_sub_folder(sub_folder)
 
@@ -2284,6 +2289,9 @@ class SaveSkinFileWidget(DataSaveFileWidget):
 
     def set_directory(self, directory, data_class=None):
         super(SaveSkinFileWidget, self).set_directory(directory, data_class)
+
+        if not self.data_class:
+            return
 
         version_up_state = self.data_class.settings.get('version up')
 

--- a/python/vtool/process_manager/ui_process_manager.py
+++ b/python/vtool/process_manager/ui_process_manager.py
@@ -45,6 +45,7 @@ signals = Signals()
 
 
 def decorator_process_run(function):
+
     @wraps(function)
     def wrapper(*args, **kwargs):
 
@@ -1628,7 +1629,7 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
 
         if util.is_in_maya():
             comment = qt_ui.get_comment(self,
-                                        
+
                                         'Note: Check previous versions in the Data Tab\n\n'
                                         'Write a comment for this save.',
 
@@ -1785,8 +1786,6 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
 
     def set_project_directory(self, directory, name=''):
 
-        log.info('Setting project directory: %s' % directory)
-
         self.handle_selection_change = False
 
         self.view_widget.tree_widget.clearSelection()
@@ -1801,6 +1800,8 @@ class ProcessManagerWindow(qt_ui.BasicWindow):
             directory = ['', str(directory)]
 
         directory = str(directory[1])
+
+        util.show('Setting project directory: %s' % directory)
 
         if directory != self.last_project:
 

--- a/python/vtool/qt_ui.py
+++ b/python/vtool/qt_ui.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 import os
+import traceback
 
 from . import qt
 
@@ -1750,7 +1751,9 @@ class FileManagerWidget(DirectoryWidget):
 
     def set_temp_sub_folder(self, folder_name):
         if not self.data_class:
+            util.warning(''.join(traceback.format_stack()[:-1]))
             util.warning('Could not set temporary sub folder.')
+
             return
         self.data_class.set_temp_sub_folder(folder_name)
 

--- a/python/vtool/util_file.py
+++ b/python/vtool/util_file.py
@@ -2448,7 +2448,8 @@ def create_dir(name, directory=None, make_unique=False):
         full_path = join_path(directory, name)
 
     if not full_path:
-        util.warning('Could not create directory. No path from name: %s and directory: %s' % (name,directory))
+        util.warning(''.join(traceback.format_stack()[:-1]))
+        util.warning('Could not create directory. No path from name: %s and directory: %s' % (name, directory))
         return False
 
     if make_unique:


### PR DESCRIPTION
This fixes some issues when switching projects
The data file widget gets it directory set to None when project is switched. These updates help handle some issues with setting the directory to None