### PR TITLE
Fix: rigs_util.create_compression_joint

### DIFF
--- a/python/vtool/maya_lib/rigs_util.py
+++ b/python/vtool/maya_lib/rigs_util.py
@@ -2037,6 +2037,7 @@ class RigSwitch(object):
 
 
 class MirrorControlKeyframes:
+
     def __init__(self, node):
         self.node = node
 
@@ -4516,8 +4517,7 @@ def create_compression_joint(joint, end_parent, description, point_constraint=Fa
     cmds.parent(loc, loc_end, group)
     cmds.parent(ik_handle, loc)
 
-    cmds.pointConstraint(parent_transform, loc, mo=True)
-    cmds.orientConstraint(parent_transform, loc, mo=True)
+    cmds.parentConstraint(parent_transform, loc, mo=True)
     if not point_constraint:
         cmds.parentConstraint(end_parent, loc_end, mo=True)
     else:


### PR DESCRIPTION
This fixes the compression joint top locator not following properly