### PR TITLE
Fix: Create curve and snap cuve

### DIFF
--- a/python/vtool/maya_lib/geo.py
+++ b/python/vtool/maya_lib/geo.py
@@ -3866,6 +3866,8 @@ def snap_joints_to_curve(joints, curve=None, count=10):
     delete_after = []
 
     if not curve:
+        if len(joints) < 2:
+            return
         curve = transforms_to_curve(joints, spans=count, description='temp')
         delete_after.append(curve)
 
@@ -3877,13 +3879,18 @@ def snap_joints_to_curve(joints, curve=None, count=10):
 
         missing_count = count - joint_count
 
+        children = cmds.listRelatives(joints[-1])
         for inc in range(0, missing_count):
-            joint = cmds.duplicate(joints[-1], n='temp_joint')[0]
+
+            joint = cmds.duplicate(joints[-1], n='temp_joint', po=True)[0]
             joint = cmds.rename(joint, core.inc_name(orig_joints[-1]))
 
             cmds.parent(joint, joints[-1])
 
             joints.append(joint)
+
+        if children:
+            cmds.parent(children, joints[-1])
 
     joint_count = len(joints)
 

--- a/python/vtool/maya_lib/ui_lib/ui_rig.py
+++ b/python/vtool/maya_lib/ui_lib/ui_rig.py
@@ -901,7 +901,9 @@ the component order should match the selected meshes.
     def _joints_on_curve(self, count):
         selection = cmds.ls(sl=True)
 
-        geo.create_oriented_joints_on_curve(selection[0], count)
+        for thing in selection:
+            if geo.is_a_curve(thing):
+                geo.create_oriented_joints_on_curve(thing, count)
 
     def _snap_joints_to_curve(self, count):
 


### PR DESCRIPTION
This fixes create joints on curve to work on multiple selected curves
It also fixes snap joints to curve when setting an joint count larger than the current selection to work in hierarchy when creating new joints. 