### PR TITLE
Fix: Referenced options

### DIFF
--- a/python/vtool/process_manager/ui_options.py
+++ b/python/vtool/process_manager/ui_options.py
@@ -1772,14 +1772,16 @@ class ProcessReferenceGroup(ProcessOptionGroup):
         option_path = util_file.get_dirname(option_file)
         option_path_current = util_file.get_dirname(option_file_current)
 
+        all_value = []
+
         if not option_path:
+            self._load_widgets(all_value)
             return
 
         settings.set_directory(option_path, name)
         settings_current.set_directory(option_path_current, name_current)
 
         option_groups = []
-        all_value = []
 
         if option_group:
             option_groups = util.convert_to_sequence(option_group)

--- a/python/vtool/process_manager/ui_options.py
+++ b/python/vtool/process_manager/ui_options.py
@@ -4,6 +4,8 @@ from __future__ import absolute_import
 
 import string
 
+import traceback
+
 from .. import qt_ui, qt
 from . import ui_code
 from .. import util
@@ -2572,14 +2574,14 @@ def get_reference_option_info(script, process_inst):
     try:
         exec(script, globals(), builtins)
     except:
-        pass
+        util.error(traceback.format_exc())
 
     path_to_process = ''
     option_group = ''
-
-    # if 'path_to_process' in builtins:
-    path_to_process = builtins['path_to_process']
-    # if 'option_group' in builtins:
-    option_group = builtins['option_group']
+    
+    if 'path_to_process' in builtins:
+        path_to_process = builtins['path_to_process']
+    if 'option_group' in builtins:
+        option_group = builtins['option_group']
 
     return path_to_process, option_group

--- a/python/vtool/util.py
+++ b/python/vtool/util.py
@@ -254,6 +254,20 @@ def initialize_env(name):
         os.environ[name] = ''
 
 
+def get_env(name):
+    """
+    Get the value of an environment variable.
+    
+    Args:
+        name (str): Name of an environment variable.
+        
+    Returns
+        str:
+    """
+    if name in os.environ:
+        return os.environ[name]
+
+
 def set_env(name, value):
     """
     Set the value of an environment variable.


### PR DESCRIPTION
When options are referenced and there's an error in the script (edit mode) reference options unload instead of leaving garbage behind. 