### PR TITLE
Fix: Unreal 54 wheel fix

### DIFF
--- a/python/vtool/ramen/rigs_unreal.py
+++ b/python/vtool/ramen/rigs_unreal.py
@@ -1004,8 +1004,7 @@ class UnrealWheelRig(UnrealUtilRig):
         graph.add_link(at_joints, 'Element', joint_metadata, 'Item', controller)
 
         graph.add_link('Entry', 'spin_control_shape', control_spin, 'color', controller)
-
-        channel_diameter = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in Parent,in Name,out Item)', unreal.Vector2D(3500, -800), 'SpawnAnimationChannel')
+        channel_diameter = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in LimitsEnabled,in Parent,in Name,out Item)', unreal.Vector2D(3500, -800), 'SpawnAnimationChannel')
         graph.add_link(joint_metadata, 'ExecuteContext', channel_diameter, 'ExecuteContext', controller)
         graph.add_link(control, 'Control', channel_diameter, 'Parent', controller)
 
@@ -1014,7 +1013,7 @@ class UnrealWheelRig(UnrealUtilRig):
         controller.set_pin_default_value(f'{n(channel_diameter)}.MaximumValue', '1000000000000.0', False)
         controller.set_pin_default_value(f'{n(channel_diameter)}.InitialValue', '9.888', False)
 
-        channel_enable = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in Parent,in Name,out Item)', unreal.Vector2D(3800, -800), 'SpawnAnimationChannel')
+        channel_enable = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in LimitsEnabled,in Parent,in Name,out Item)', unreal.Vector2D(3800, -800), 'SpawnAnimationChannel')
         graph.add_link(channel_diameter, 'ExecuteContext', channel_enable, 'ExecuteContext', controller)
         graph.add_link(control, 'Control', channel_enable, 'Parent', controller)
 
@@ -1022,7 +1021,7 @@ class UnrealWheelRig(UnrealUtilRig):
         controller.resolve_wild_card_pin(f'{n(channel_enable)}.InitialValue', 'float', unreal.Name())
         controller.set_pin_default_value(f'{n(channel_enable)}.InitialValue', '1.0', False)
 
-        channel_multiply = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in Parent,in Name,out Item)', unreal.Vector2D(4100, -800), 'SpawnAnimationChannel')
+        channel_multiply = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in LimitsEnabled,in Parent,in Name,out Item)', unreal.Vector2D(4100, -800), 'SpawnAnimationChannel')
         graph.add_link(channel_enable, 'ExecuteContext', channel_multiply, 'ExecuteContext', controller)
         graph.add_link(control, 'Control', channel_multiply, 'Parent', controller)
 

--- a/python/vtool/ramen/rigs_unreal.py
+++ b/python/vtool/ramen/rigs_unreal.py
@@ -1004,28 +1004,25 @@ class UnrealWheelRig(UnrealUtilRig):
         graph.add_link(at_joints, 'Element', joint_metadata, 'Item', controller)
 
         graph.add_link('Entry', 'spin_control_shape', control_spin, 'color', controller)
-        channel_diameter = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in LimitsEnabled,in Parent,in Name,out Item)', unreal.Vector2D(3500, -800), 'SpawnAnimationChannel')
+        channel_diameter = graph.add_animation_channel(controller, 'Diameter')
         graph.add_link(joint_metadata, 'ExecuteContext', channel_diameter, 'ExecuteContext', controller)
         graph.add_link(control, 'Control', channel_diameter, 'Parent', controller)
 
-        controller.set_pin_default_value(f'{n(channel_diameter)}.Name', 'Diameter', False)
         controller.resolve_wild_card_pin(f'{n(channel_diameter)}.InitialValue', 'float', unreal.Name())
         controller.set_pin_default_value(f'{n(channel_diameter)}.MaximumValue', '1000000000000.0', False)
         controller.set_pin_default_value(f'{n(channel_diameter)}.InitialValue', '9.888', False)
 
-        channel_enable = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in LimitsEnabled,in Parent,in Name,out Item)', unreal.Vector2D(3800, -800), 'SpawnAnimationChannel')
+        channel_enable = graph.add_animation_channel(controller, 'Enable')
         graph.add_link(channel_diameter, 'ExecuteContext', channel_enable, 'ExecuteContext', controller)
         graph.add_link(control, 'Control', channel_enable, 'Parent', controller)
 
-        controller.set_pin_default_value(f'{n(channel_enable)}.Name', 'Enable', False)
         controller.resolve_wild_card_pin(f'{n(channel_enable)}.InitialValue', 'float', unreal.Name())
         controller.set_pin_default_value(f'{n(channel_enable)}.InitialValue', '1.0', False)
 
-        channel_multiply = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in LimitsEnabled,in Parent,in Name,out Item)', unreal.Vector2D(4100, -800), 'SpawnAnimationChannel')
+        channel_multiply = graph.add_animation_channel(controller, 'RotateMultiply')
         graph.add_link(channel_enable, 'ExecuteContext', channel_multiply, 'ExecuteContext', controller)
         graph.add_link(control, 'Control', channel_multiply, 'Parent', controller)
 
-        controller.set_pin_default_value(f'{n(channel_multiply)}.Name', 'RotateMultiply', False)
         controller.resolve_wild_card_pin(f'{n(channel_multiply)}.InitialValue', 'float', unreal.Name())
         controller.set_pin_default_value(f'{n(channel_multiply)}.InitialValue', '1.0', False)
 

--- a/python/vtool/unreal_lib/graph.py
+++ b/python/vtool/unreal_lib/graph.py
@@ -7,7 +7,7 @@ if util.in_unreal:
 current_control_rig = None
 
 
-def name(unreal_node):
+def n(unreal_node):
     if type(unreal_node) == str:
         return unreal_node
     else:
@@ -451,4 +451,18 @@ def move_nodes(position_x, position_y, list_of_node_instances, controller):
 
 
 def add_link(source_node, source_attribute, target_node, target_attribute, controller):
-    controller.add_link(f'{name(source_node)}.{source_attribute}', f'{name(target_node)}.{target_attribute}')
+    controller.add_link(f'{n(source_node)}.{source_attribute}', f'{n(target_node)}.{target_attribute}')
+
+
+def add_animation_channel(controller, name):
+
+    version = util.get_unreal_version()
+    if version[0] <= 5 and version[1] <= 3:
+        channel = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in Parent,in Name,out Item)', unreal.Vector2D(3500, -800), 'SpawnAnimationChannel')
+
+    if version[0] <= 5 and version[1] >= 4:
+        channel = controller.add_template_node('SpawnAnimationChannel::Execute(in InitialValue,in MinimumValue,in MaximumValue,in LimitsEnabled,in Parent,in Name,out Item)', unreal.Vector2D(3500, -800), 'SpawnAnimationChannel')
+
+    controller.set_pin_default_value(f'{n(channel)}.Name', name, False)
+
+    return channel

--- a/python/vtool/util.py
+++ b/python/vtool/util.py
@@ -537,6 +537,17 @@ def get_maya_version():
         return 0
 
 
+def get_unreal_version():
+    if in_unreal:
+        import unreal
+        version = unreal.SystemLibrary.get_engine_version()
+        split_version = version.split('.')
+
+        return [int(split_version[0]), int(split_version[1])]
+
+    unreal.SystemLibrary.get_engine_version()
+
+
 def break_signaled():
     """
     Check to see if Vetala break was signalled.


### PR DESCRIPTION
This fixes the adding animation channels erroring on creation in Unreal 5.4 because they changed the inputs needed. 