### PR TITLE
Improvement: space.create_mulit_follow title tweak

### DIFF
--- a/python/vtool/maya_lib/space.py
+++ b/python/vtool/maya_lib/space.py
@@ -703,8 +703,8 @@ class ConstraintEditor(object):
                 parent = cmds.listRelatives(target, p=True)
                 if parent:
                     parent = parent[0]
-                    if parent.startswith('CNT_'):
-                        name = parent
+                    # if parent.startswith('CNT_'):
+                    name = parent
             name = '%s %s' % (inc, name)
             names.append(name)
 


### PR DESCRIPTION
Just a small tweak, create_multi_follow now uses the names of the transform driving the follow in the title instead of the follower prefixed names.