### PR TITLE
Fix: blendshape.Blenshape.create_target error when nothing pruned.

### DIFF
--- a/python/vtool/maya_lib/blendshape.py
+++ b/python/vtool/maya_lib/blendshape.py
@@ -370,9 +370,9 @@ class BlendShape(object):
             target_fn = api.MeshFunction(target_object)
             target_fn.set_vertex_positions(positions)
 
-            target_mesh = temp_target
+        target_mesh = temp_target
 
-            return target_mesh
+        return target_mesh
 
     # --- blendshape deformer
 


### PR DESCRIPTION
when using create_target in the blendshape.Blendshape class the target would error if pruning was set but there was nothing to prune. 