### PR TITLE
Fix: Maya Ramen unbuild zero out controls only if under parent.

### DIFF
--- a/python/vtool/ramen/rigs_maya.py
+++ b/python/vtool/ramen/rigs_maya.py
@@ -394,8 +394,13 @@ class MayaUtilRig(rigs.PlatformUtilRig):
             if not cmds.objExists(control):
                 continue
 
-            attr.zero_xform_channels(control)
-        cmds.refresh()
+            stored_parent = attr.get_message_input(control, 'parent')
+
+            other_parent = cmds.listRelatives(control, p=True)
+            if other_parent:
+                if stored_parent == other_parent[0]:
+                    attr.zero_xform_channels(control)
+        core.refresh()
         for control in self._controls:
             rels = cmds.listRelatives(control, ad=True, type='transform', f=True)
 

--- a/python/vtool/ramen/ui_lib/ui_nodes.py
+++ b/python/vtool/ramen/ui_lib/ui_nodes.py
@@ -4063,7 +4063,7 @@ class RigItem(NodeItem):
         if in_unreal:
             unreal_lib.graph.close_undo('Node Run')
 
-            #self._handle_unreal_connections()
+            # self._handle_unreal_connections()
 
     def _handle_platform_connections(self):
 
@@ -4156,7 +4156,6 @@ class RigItem(NodeItem):
             apex.addWire(source_port, target_port)
 
             houdini_lib.graph.update_apex_graph(apex_edit, apex)
-
 
     def _disconnect_unreal(self):
 
@@ -4549,7 +4548,6 @@ def disconnect_socket(target_socket, run_target=True):
                 nodes = _get_nodes()
                 handle_unreal_evaluation(nodes)
 
-
     target_socket.lines = []
 
     if in_houdini:
@@ -4567,8 +4565,7 @@ def disconnect_socket(target_socket, run_target=True):
             apex.removeWire(source_port, target_port)
             houdini_lib.graph.update_apex_graph(apex_edit, apex)
 
-    target_socket.remove_line(target_socket.lines[0])
-
+    # target_socket.remove_line(target_socket.lines[0])
 
     if target_socket.data_type == rigs.AttrType.TRANSFORM:
         if source_node:


### PR DESCRIPTION
Unbuilding is difficult in Maya.  Controls get unparented before a section of the rig unbuilds.  Sometimes its good to zero out the controls so they go back to their original positions.  This is good to do when the control is living under it's tagged parent.  If not it causes drifting.  A check was added to see if a control is under it's tagged parent to avoid the drifting.  Zeroing out is preserved because it allows the rig to go back to its default pose before removing a section of the rig.  This helps any children rigs to be in the right position when their parent rig is removed. 