### PR TITLE
Fix: transfer_blendshape_targets when using wrap_mesh.

### DIFF
--- a/python/vtool/maya_lib/blendshape.py
+++ b/python/vtool/maya_lib/blendshape.py
@@ -3199,7 +3199,10 @@ def transfer_blendshape_targets(blend_source,
         if not orig_geo:
             orig_geo = mesh
         source_base = cmds.duplicate(orig_geo, n='source_base')[0]
-        cmds.parent(source_base, w=True)
+        try:
+            cmds.parent(source_base, w=True)
+        except:
+            pass
         to_delete_last.append(source_base)
 
     if use_uv:

--- a/python/vtool/maya_lib/blendshape.py
+++ b/python/vtool/maya_lib/blendshape.py
@@ -3201,7 +3201,7 @@ def transfer_blendshape_targets(blend_source,
         source_base = cmds.duplicate(orig_geo, n='source_base')[0]
         try:
             cmds.parent(source_base, w=True)
-        except:
+        except RuntimeError:
             pass
         to_delete_last.append(source_base)
 


### PR DESCRIPTION
If the source mesh was parented under world it would error.