### PR TITLE
Fix: move reload module to save instead of run, and only reload saved

### DIFF
--- a/python/vtool/process_manager/process.py
+++ b/python/vtool/process_manager/process.py
@@ -2915,20 +2915,6 @@ class Process(object):
         watch.start(feedback=False)
         self._setup_options()
 
-        modules = sys.modules
-        found = []
-
-        for key in modules:
-            module = modules[key]
-            if not hasattr(module, '__file__'):
-                continue
-            if not module.__file__:
-                continue
-            if module.__file__.find('/.code\\') > -1 or module.__file__.find('/.code/') > -1:
-                found.append(key)
-
-        [modules.pop(key) for key in found]
-
         sys.path.append(self.get_code_path())
 
         orig_script = script

--- a/python/vtool/qt_ui.py
+++ b/python/vtool/qt_ui.py
@@ -3549,6 +3549,24 @@ class CodeEditTabs(BasicWidget):
 
         filepath = current_widget.filepath
 
+        modules = sys.modules
+        found = []
+        path1 = util_file.fix_slashes(filepath)
+
+        for key in modules:
+            module = modules[key]
+            if not hasattr(module, '__file__'):
+                continue
+            if not module.__file__:
+                continue
+            if module.__file__.find('/.code\\') > -1 or module.__file__.find('/.code/') > -1:
+                path2 = util_file.fix_slashes(module.__file__)
+                if path1 == path2:
+                    found.append(key)
+
+        for key in found:
+            modules.pop(key)
+
         if hasattr(current_widget, 'text_edit'):
             util.warning('Passed in widget to save was not a text edit')
             current_widget = current_widget.text_edit


### PR DESCRIPTION
When vetala loads a python file and runs it, its handling some of the sourcing itself.  This saves the user having to do imp.reload().
However in the previous release modules were reloading every time a script was run.
Now they reload on save.   
This brings the behavior back to how it was working before, with just the addition of reloading the module on save. 