### PR TITLE
Fix: deform.TransferWeight.transfer_joint_to_joint

### DIFF
--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -1802,6 +1802,8 @@ class TransferWeight(object):
 
         source_joints = util.convert_to_sequence(source_joints)
         destination_joints = util.convert_to_sequence(destination_joints)
+        
+        destination_joints_long = cmds.ls(destination_joints, type='joint', l=True)
 
         if os.environ.get('VETALA_RUN') == 'True':
             if os.environ.get('VETALA_STOP') == 'True':
@@ -1899,11 +1901,8 @@ class TransferWeight(object):
         unlock_joint_weights(self.skin_cluster)
         indices = get_skin_influence_indices(self.skin_cluster)
         locks = []
-        for influence_index in indices:
-            if influence_index in all_influences:
-                lock_influence = get_skin_influence_at_index(influence_index, self.skin_cluster)
-                locks.append(lock_influence)
-        lock_joint_weights(self.skin_cluster, locks)
+        lock_joints = destination_joints_long
+        lock_joint_weights(self.skin_cluster,lock_joints)
 
         if not source_influences:
             return
@@ -1941,8 +1940,7 @@ class TransferWeight(object):
 
                 if value > destination_value:
                     value = destination_value
-
-                value = value * destination_value
+                value *= percent
 
                 if value > 1:
                     value = 1.0

--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -1802,7 +1802,7 @@ class TransferWeight(object):
 
         source_joints = util.convert_to_sequence(source_joints)
         destination_joints = util.convert_to_sequence(destination_joints)
-        
+
         destination_joints_long = cmds.ls(destination_joints, type='joint', l=True)
 
         if os.environ.get('VETALA_RUN') == 'True':
@@ -1899,10 +1899,7 @@ class TransferWeight(object):
         all_influences = source_influences + dest_influences
 
         unlock_joint_weights(self.skin_cluster)
-        indices = get_skin_influence_indices(self.skin_cluster)
-        locks = []
-        lock_joints = destination_joints_long
-        lock_joint_weights(self.skin_cluster,lock_joints)
+        lock_joint_weights(self.skin_cluster, destination_joints_long)
 
         if not source_influences:
             return

--- a/python/vtool/maya_lib/deform.py
+++ b/python/vtool/maya_lib/deform.py
@@ -1941,7 +1941,6 @@ class TransferWeight(object):
 
                 if value > destination_value:
                     value = destination_value
-                value *= percent
 
                 value = value * destination_value
 


### PR DESCRIPTION
There was a multiplication of the weights happening per vert that causes the source joints to not completely take over the destination joints if the destination joints didn't have a total weight that added to 1. 

Simply removing the line
`value = value * destination_value `
seems to be the fix