### PR TITLE
Fix: This adds clusters to the rig control group size for FkCurveRig

### DIFF
--- a/python/vtool/maya_lib/rigs.py
+++ b/python/vtool/maya_lib/rigs.py
@@ -3209,6 +3209,12 @@ class SplineRibbonBaseRig(JointRig):
         cluster_group = self._create_setup_group('clusters')
         cmds.parent(self.clusters, cluster_group)
 
+        to_scale = cluster_surface.handles
+        for transform in to_scale:
+            cmds.connectAttr('%s.sizeX' % self.control_group, '%s.scaleX' % transform)
+            cmds.connectAttr('%s.sizeY' % self.control_group, '%s.scaleY' % transform)
+            cmds.connectAttr('%s.sizeZ' % self.control_group, '%s.scaleZ' % transform)
+
         return self.clusters
 
     def _create_geo(self, span_count):


### PR DESCRIPTION
When scaling FkCurveRig to a small amount, the clusters would offset slightly.  This was already fixed on TweakCurveRig