### PR TITLE
Fix get_option returning list[str] instead of str for an empty string

### DIFF
--- a/python/vtool/process_manager/process.py
+++ b/python/vtool/process_manager/process.py
@@ -692,7 +692,9 @@ class Process(object):
 
         if util.is_str(value):
             new_value = util.convert_str_to_list(value)
-            if len(new_value) == 1:
+            if len(new_value) == 0:
+                new_value = ''
+            elif len(new_value) == 1:
                 new_value = new_value[0]
 
         if self._option_result_function:
@@ -4234,3 +4236,4 @@ def run_deadline(process_directory, name, parent_jobs=None, batch_name=None):
     job_id = job.submit()
 
     return job_id
+


### PR DESCRIPTION
Hello again!

While testing the latest vetala (we are upgrading from v0.6.8.0 to v0.7.0.1), we spotted a small regression in the API.

Our setup have string options, which can be empty:

<img width="188" height="124" alt="image" src="https://github.com/user-attachments/assets/951ff047-548f-433f-926d-1be294c6b637" />

Since v0.6.8.1, obtaining the value of `Custom Name` return `[]` instead of `''`.

```
process.get_option_match('Custom Name')  # this will return a list
```

This seem related to these two commits: 
- https://github.com/louisVottero/vtool/commit/64b5f5789071c10a12d47a07e2324b9a1025af9e
- https://github.com/louisVottero/vtool/commit/31533fb242076f786713428f6582af5eb9a6f3d9

Before and after the changes, `_format_option_value` return `list[str]` instead of `str` if the value contain `,`.
However the behavior for empty string changed. Previously it returned `''` but now it's returning `[]`.

Is this intended? If yes, feel free to close this MR and we’ll adjust downstream.

P.S. The file had mixed line endings (LF and CRLF). I normalized them, which adds a few unrelated modified lines.