### PR TITLE
Fix: process.run_script when not in manifest, works basename eg script.py

### DIFF
--- a/python/vtool/process_manager/process.py
+++ b/python/vtool/process_manager/process.py
@@ -2899,13 +2899,18 @@ class Process(object):
             if not util_file.is_file(script):
                 script = self.get_first_matching_code(script)
         if not script:
+            # having this second _get_code_file
+            # insures manifest entries have priority.
             script = self._get_code_file(orig_script)
 
         return script
 
     # --- run
     @decorator_process_run_script
-    def run_script(self, script, hard_error=True, settings=None, return_status=False):
+    def run_script(self, script,
+                   hard_error=True,
+                   settings=None,
+                   return_status=False):
         """
         Run a script in the process.
 


### PR DESCRIPTION
You can run a script from the manifest by simply doing
process.run_script('script name')
This pull request fixes script running when the script is outside of the manifest. 
The name of the script must not match a manifest entry and must include .py
for example:
process.run_script('script.py')
To access scripts that are not in the manifest, click on the Scripts tab beside Manifest tab. 