### PR TITLE
Fix: negative scale parent constraint

### DIFF
--- a/python/vtool/maya_lib/rigs.py
+++ b/python/vtool/maya_lib/rigs.py
@@ -1515,11 +1515,7 @@ class SparseRig(JointRig):
                 if sub:
                     const_control = sub.control
 
-                maintain_offset = True
-                if space.world_matrix_equivalent(const_control, joint):
-                    maintain_offset = False
-
-                cmds.parentConstraint(const_control, joint, mo=maintain_offset)
+                space.parent_constraint_equivalent(const_control, joint)
 
                 if self.is_scalable:
                     if self.keep_negative_scale:
@@ -2319,21 +2315,7 @@ class FkRig(BufferRig):
                 offset_rotation = self.inc_offset_rotation[self.current_increment]
                 cmds.xform(xform, ro=offset_rotation, r=True, os=True)
 
-        maintain_offset = True
-
-        equivalent = space.world_matrix_equivalent(control, target_transform)
-        if equivalent:
-            maintain_offset = False
-
-        pre_rotate = cmds.getAttr('%s.rotate' % target_transform)[0]
-        const = cmds.parentConstraint(control, target_transform, mo=maintain_offset)
-        post_rotate = cmds.getAttr('%s.rotate' % target_transform)[0]
-
-        dist = util_math.get_distance_before_sqrt(pre_rotate, post_rotate)
-        if dist > 0.000001:
-            cmds.delete(const)
-            cmds.setAttr('%s.rotate' % target_transform, pre_rotate[0], pre_rotate[1], pre_rotate[2])
-            cmds.parentConstraint(control, target_transform, mo=not maintain_offset)
+        space.parent_constraint_equivalent(control, target_transform)
 
     def _convert_to_joints(self):
         for inc in range(0, len(self.controls)):

--- a/python/vtool/maya_lib/space.py
+++ b/python/vtool/maya_lib/space.py
@@ -3415,17 +3415,8 @@ def world_matrix_equivalent(transform1, transform2):
 def has_negative_scale(transform):
 
     matrix_list = cmds.getAttr(f'{transform}.worldMatrix')
-    mat = om.MMatrix(matrix_list)
 
-    # Extract the 3x3 determinant (orientation & scale sign)
-    # A negative determinant indicates an odd number of negative scale axes (reflection)
-    det = (
-        mat[0] * (mat[5] * mat[10] - mat[6] * mat[9]) -
-        mat[1] * (mat[4] * mat[10] - mat[6] * mat[8]) +
-        mat[2] * (mat[4] * mat[9] - mat[5] * mat[8])
-    )
-
-    return det < 0.0
+    return util_math.has_negative_scale(matrix_list)
 
 
 def parent_constraint_equivalent(transform1, transform2):

--- a/python/vtool/maya_lib/space.py
+++ b/python/vtool/maya_lib/space.py
@@ -3412,6 +3412,49 @@ def world_matrix_equivalent(transform1, transform2):
     return equivalent
 
 
+def has_negative_scale(transform):
+
+    matrix_list = cmds.getAttr(f'{transform}.worldMatrix')
+    mat = om.MMatrix(matrix_list)
+
+    # Extract the 3x3 determinant (orientation & scale sign)
+    # A negative determinant indicates an odd number of negative scale axes (reflection)
+    det = (
+        mat[0] * (mat[5] * mat[10] - mat[6] * mat[9]) -
+        mat[1] * (mat[4] * mat[10] - mat[6] * mat[8]) +
+        mat[2] * (mat[4] * mat[9] - mat[5] * mat[8])
+    )
+
+    return det < 0.0
+
+
+def parent_constraint_equivalent(transform1, transform2):
+    """
+    This is specifically for negative scale cases.
+    When transforms are equivalent:  sometimes turning off maintain offset can keep original values.
+    """
+
+    if has_negative_scale(transform2):
+
+        maintain_offset = True
+
+        equivalent = world_matrix_equivalent(transform1, transform2)
+        if equivalent:
+            maintain_offset = False
+
+        pre_rotate = cmds.getAttr('%s.rotate' % transform2)[0]
+        const = cmds.parentConstraint(transform1, transform2, mo=maintain_offset)
+        post_rotate = cmds.getAttr('%s.rotate' % transform2)[0]
+
+        dist = util_math.get_distance_before_sqrt(pre_rotate, post_rotate)
+        if dist > 0.000001:
+            cmds.delete(const)
+            cmds.setAttr('%s.rotate' % transform2, pre_rotate[0], pre_rotate[1], pre_rotate[2])
+            cmds.parentConstraint(transform1, transform2, mo=not maintain_offset)
+    else:
+        cmds.parentConstraint(transform1, transform2, mo=True)
+
+
 def get_ik_from_joint(joint):
     outputs = attr.get_attribute_outputs('%s.message' % joint, True)
 
@@ -4299,9 +4342,8 @@ def constrain_local(source_transform, target_transform, parent=False, scale_conn
         if equivalent:
             maintain_offset = False
         if constraint == 'parentConstraint':
-            cmds.parentConstraint(local_group,
-                                  target_transform,
-                                  mo=maintain_offset)
+            parent_constraint_equivalent(local_group,
+                                         target_transform)
         if constraint == 'pointConstraint':
             cmds.pointConstraint(local_group,
                                  target_transform,

--- a/python/vtool/util_math.py
+++ b/python/vtool/util_math.py
@@ -1043,6 +1043,18 @@ def mirror_matrix(matrix, axis=[1, 0, 0], translation=True):
     return matrix
 
 
+def has_negative_scale(matrix):
+    # Extract the 3x3 determinant (orientation & scale sign)
+    # A negative determinant indicates an odd number of negative scale axes (reflection)
+    det = (
+        matrix[0] * (matrix[5] * matrix[10] - matrix[6] * matrix[9]) -
+        matrix[1] * (matrix[4] * matrix[10] - matrix[6] * matrix[8]) +
+        matrix[2] * (matrix[4] * matrix[9] - matrix[5] * matrix[8])
+    )
+
+    return det < 0.0
+
+
 def invert_rotation_axes(matrix, invert_x=False, invert_y=False, invert_z=False):
     """
     This uses a 4x4 matrix in a 16 element iteratable. Similar to Maya's matrix.


### PR DESCRIPTION
This will check if a joint has negative scale and then it will check if the control and joint have equivalent matrices. If they are then maintain offset is turned off, which in some cases maintains rotate values.  In cases where this changes rotate values maintain offset is turned back on. 